### PR TITLE
Line chart - Empty column instead of zero point

### DIFF
--- a/website-generator/resources/src/line_chart.js
+++ b/website-generator/resources/src/line_chart.js
@@ -37,7 +37,7 @@
       ['', '']
     ].concat(labels.slice(-displayDataCount)).concat(['']),
     datasets: [{
-      data: [0].concat(data.slice(-displayDataCount)),
+      data: ['None'].concat(data.slice(-displayDataCount)),
       label: 'Passed',
       fill: true,
       backgroundColor: 'transparent',


### PR DESCRIPTION
Changes on backend details page. Empty column instead of zero point in line chart (trend).