### PR TITLE
fix StringNormalizer test failures for onnxruntime backend 

### DIFF
--- a/runtimes/onnx-runtime/development/Dockerfile
+++ b/runtimes/onnx-runtime/development/Dockerfile
@@ -3,11 +3,12 @@ FROM ubuntu:18.04
 # Disable interactive installation mode
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Python dependencies
+# Install Python and locales dependencies
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-dev \
-    python3-pip && \
+    python3-pip \
+    locales && \
     apt-get clean autoclean && apt-get autoremove -y
 
 RUN pip3 install --upgrade pip setuptools wheel
@@ -21,6 +22,9 @@ RUN pip3 install --no-cache-dir -r /root/setup/requirements_report.txt
 
 ############## ONNX Backend dependencies ###########
 ENV ONNX_BACKEND="onnxruntime.backend.backend"
+
+# Set locale which is required for StringNormalizer
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
 
 # Install dependencies
 RUN pip3 install onnx

--- a/runtimes/onnx-runtime/stable/Dockerfile
+++ b/runtimes/onnx-runtime/stable/Dockerfile
@@ -3,11 +3,12 @@ FROM ubuntu:18.04
 # Disable interactive installation mode
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install Python dependencies
+# Install Python and locales dependencies
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-dev \
-    python3-pip && \
+    python3-pip \
+    locales && \
     apt-get clean autoclean && apt-get autoremove -y
 
 RUN pip3 install --upgrade pip setuptools wheel
@@ -21,6 +22,9 @@ RUN pip3 install --no-cache-dir -r /root/setup/requirements_report.txt
 
 ############## ONNX Backend dependencies ###########
 ENV ONNX_BACKEND="onnxruntime.backend.backend"
+
+# Set locale which is required for StringNormalizer
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
 
 # Install dependencies
 RUN pip3 install onnx


### PR DESCRIPTION
There are 12 test failures for onnxruntime backend related to StringNormalizer.
The errors show
E       onnxruntime.capi.onnxruntime_pybind11_state.RuntimeException: [ONNXRuntimeError] : 6 : RUNTIME_EXCEPTION : Exception during initialization: /onnxruntime_src/onnxruntime/core/pro
viders/cpu/nn/string_normalizer.cc:87 onnxruntime::string_normalizer::Locale::Locale(const string&) Failed to construct locale with name:en_US.UTF-8:locale::facet::_S_create_c_locale na
me not valid:Please, install necessary language-pack-XX and configure locales

The root cause is the docker image doesn't install and configure locales per [onnxruntime README.md ](https://github.com/microsoft/onnxruntime/blob/master/README.md#system-language)

This PR adds the necessary locales installation and configuration. The previously failing tests pass after applying this fix. 