### PR TITLE
Update Tensorflow version to latest for onnx-tf

### DIFF
--- a/runtimes/onnx-tf/stable/Dockerfile
+++ b/runtimes/onnx-tf/stable/Dockerfile
@@ -25,7 +25,7 @@ ENV ONNX_BACKEND="onnx_tf.backend"
 # Install dependencies
 RUN pip3 install --no-cache-dir \
     onnx \
-    "tensorflow<2.0" \
+    tensorflow \
     onnx-tf
 ####################################################
 


### PR DESCRIPTION
Update Tensorflow version to latest for onnx-tf since the
official onnx-tf 1.7 supports TF 2.x, not TF 1.x.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>