### PR TITLE
Temporarily build ONNX from source code with bug fix

### DIFF
--- a/runtimes/onnx-runtime/stable/Dockerfile
+++ b/runtimes/onnx-runtime/stable/Dockerfile
@@ -5,12 +5,21 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install Python and locales dependencies
 RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-dev \
-    python3-pip \
+    git \
+    cmake \
+    protobuf-compiler \
+    libprotoc-dev \
+    python3.7 \
+    python3.7-dev \
+    python3.7-distutils \
+    python3-setuptools \
+    curl \
+    build-essential \
     locales && \
     apt-get clean autoclean && apt-get autoremove -y
 
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3.7 get-pip.py
 RUN pip3 install --upgrade pip setuptools wheel
 
 # Copy local directories
@@ -27,7 +36,12 @@ ENV ONNX_BACKEND="onnxruntime.backend.backend"
 RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
 
 # Install dependencies
-RUN pip3 install onnx
+RUN mkdir /root/app && \
+    cd /root/app && \
+    git clone -b etusien/fix_get_schema https://github.com/Ewa21/onnx.git && \
+    cd onnx && \
+    git submodule update --init --recursive && \
+    python3.7 setup.py install
 RUN pip3 install onnxruntime
 ####################################################
 

--- a/runtimes/onnx-runtime/stable/Dockerfile
+++ b/runtimes/onnx-runtime/stable/Dockerfile
@@ -35,14 +35,19 @@ ENV ONNX_BACKEND="onnxruntime.backend.backend"
 # Set locale which is required for StringNormalizer
 RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
 
-# Install dependencies
+# Temporarily build ONNX from source due to bug fixed in PR #3256 in onnx/onnx
+# After ONNX>1.8.1 is released, revert https://github.com/onnx/backend-scoreboard/pull/24
 RUN mkdir /root/app && \
     cd /root/app && \
-    git clone -b etusien/fix_get_schema https://github.com/Ewa21/onnx.git && \
+    git clone https://github.com/onnx/onnx.git && \
     cd onnx && \
     git submodule update --init --recursive && \
     python3.7 setup.py install
-RUN pip3 install onnxruntime
+
+# Install dependencies
+RUN pip3 install \
+    # onnx \
+    onnxruntime 
 ####################################################
 
 CMD . /root/setup/docker-setup.sh && \


### PR DESCRIPTION
Backend Scoreboard temporarily needs to build ONNX from source code with the bug fix provided in this PR https://github.com/onnx/onnx/pull/3256.
These changes are introduced due to a bug in the ONNX library. More details in the issue https://github.com/onnx/onnx/issues/3237.