### PR TITLE
[ONNX-TF] Temporarily build ONNX from source code with bug fix

### DIFF
--- a/runtimes/onnx-tf/stable/Dockerfile
+++ b/runtimes/onnx-tf/stable/Dockerfile
@@ -33,7 +33,7 @@ RUN pip3 install --no-cache-dir -r /root/setup/requirements_report.txt
 ENV ONNX_BACKEND="onnx_tf.backend"
 
 # Temporarily build ONNX from source due to bug fixed in PR #3256 in onnx/onnx
-# After ONNX>1.8.1 is released, revert https://github.com/onnx/backend-scoreboard/pull/25
+# After ONNX>1.8.1 is released, revert https://github.com/onnx/backend-scoreboard/pull/27
 RUN mkdir /root/app && \
     cd /root/app && \
     git clone https://github.com/onnx/onnx.git && \

--- a/runtimes/onnx-tf/stable/Dockerfile
+++ b/runtimes/onnx-tf/stable/Dockerfile
@@ -5,12 +5,22 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install Python dependencies
 RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-dev \
-    python3-pip && \
+    git \
+    cmake \
+    protobuf-compiler \
+    libprotoc-dev \
+    python3.7 \
+    python3.7-dev \
+    python3.7-distutils \
+    python3-setuptools \
+    curl \
+    build-essential && \
     apt-get clean autoclean && apt-get autoremove -y
 
+RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+RUN python3.7 get-pip.py
 RUN pip3 install --upgrade pip setuptools wheel
+RUN python3.7 -m pip install protobuf
 
 # Copy local directories
 COPY ./test /root/test
@@ -22,9 +32,18 @@ RUN pip3 install --no-cache-dir -r /root/setup/requirements_report.txt
 ############## ONNX Backend dependencies ###########
 ENV ONNX_BACKEND="onnx_tf.backend"
 
+# Temporarily build ONNX from source due to bug fixed in PR #3256 in onnx/onnx
+# After ONNX>1.8.1 is released, revert https://github.com/onnx/backend-scoreboard/pull/25
+RUN mkdir /root/app && \
+    cd /root/app && \
+    git clone https://github.com/onnx/onnx.git && \
+    cd onnx && \
+    git submodule update --init --recursive && \
+    python3.7 setup.py install
+
 # Install dependencies
 RUN pip3 install --no-cache-dir \
-    onnx \
+    # onnx \
     tensorflow \
     onnx-tf
 ####################################################


### PR DESCRIPTION
Backend Scoreboard temporarily needs to build ONNX from source code with the bug fix provided in this PR onnx/onnx#3256.
These changes are introduced due to a bug in the ONNX library. More details in the issue onnx/onnx#3237.

These changes will be removed when the new ONNX version is released.