### PR TITLE
Update ubuntu image from 20.04 to 22.04

### DIFF
--- a/runtimes/onnx-runtime/stable/Dockerfile
+++ b/runtimes/onnx-runtime/stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # Disable interactive installation mode
 ENV DEBIAN_FRONTEND=noninteractive

--- a/setup/requirements_report.txt
+++ b/setup/requirements_report.txt
@@ -1,2 +1,3 @@
-pytest==5.2.1
-tabulate==0.8.3
+pytest>=7.0.0
+tabulate>=0.8.10
+PyYAML>=6.0


### PR DESCRIPTION
The latest [runs of the scoreboard](https://onnx.ai/backend-scoreboard/onnxruntime_details_stable.html) seem to be using `onnxruntime 1.19.2`, while the latest published version is currently [`1.21.0`](https://pypi.org/project/onnxruntime/).

If you try to update the [`pip3 install`](https://github.com/onnx/backend-scoreboard/blob/03d85dca776738993c177aa019e1ccce6a824eb3/runtimes/onnx-runtime/stable/Dockerfile#L30) command in the Dockerfile to `pip3 install onnxruntime==1.21.0`, you get this output:
```
- 0.714   Downloading onnx-1.17.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (16 kB)
- 0.791 ERROR: Could not find a version that satisfies the requirement onnxruntime==1.21.0 (from versions: 1.2.0, 1.3.0, 1.4.0, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0, 1.8.1, 1.9.0, 1.10.0, 1.11.0, 1.11.1, 1.12.0, 1.12.1, 1.13.1, 1.14.0, 1.14.1, 1.15.0, 1.15.1, 1.16.0, 1.16.1, 1.16.2, 1.16.3, 1.17.0, 1.17.1, 1.17.3, 1.18.0, 1.18.1, 1.19.0, 1.19.2)
```

This indicates that the latest `onnxruntime` package version is not even available, and also that the Python version that is used is 3.8. However, since the [onnxruntime 1.20.0 release](https://github.com/Microsoft/onnxruntime/releases/tag/v1.20.0), the support for Python 3.8 has been dropped:
```
ONNX Runtime packages will stop supporting Python 3.8 and Python 3.9. This decision aligns with NumPy Python version support. To continue using ORT with Python 3.8 and Python 3.9, you can use ORT 1.19.2 and earlier.
```

So in order to be able to install the latest `onnxruntime` package, we would like to use the latest version of Python. One way to do this is to update the base ubuntu image. The `20.04` Ubuntu release will reach its End of Standard Support in [May 2025](https://wiki.ubuntu.com/Releases), so we should make this update regardless.

I also tried using the `24.04` image, but then I get an error building the image with:
```
docker build -t scoreboard/onnx -f runtimes/onnx-runtime/stable/Dockerfile .
```

With `22.04` the above command works and I've confirmed the latest onnxruntime (`1.21.0`) is installed now. I would like to keep the changes to the Dockerfile minimal, which is why I only updated to the `22.04` Ubuntu image for now.

The versions of a few packages had to be updated as well in order to be able to run the tests. I have validated that the command below works with these changes and successfully runs the tests:
```
docker run --name onnx-runtime --env-file setup/env.list -v ~/backend-scoreboard/results/onnx-runtime/stable:/root/results scoreboard/onnx
```
