### PR TITLE
Improve charts

### DIFF
--- a/backends/tvm/backend.py
+++ b/backends/tvm/backend.py
@@ -1,12 +1,37 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""ONNX backend wrapper for Apache TVM (Relay frontend)."""
+"""ONNX backend wrapper for Apache TVM (Relay frontend, native ops only)."""
 
+import logging
 import multiprocessing as mp
+import sys
 
 import numpy as np
 from onnx.backend.base import Backend, BackendRep
 from onnx.backend.test.runner import BackendIsNotSupposedToImplementIt
+
+logging.basicConfig(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+
+
+def _native_ops_only(model):
+    """Return ops in the model that have no native TVM Relay converter.
+
+    Uses TVM's internal converter map to detect ops that would silently fall
+    back to the ONNX reference runtime instead of being compiled natively.
+    Returns an empty list when the check cannot be performed.
+    """
+    try:
+        from tvm.relay.frontend.onnx import _get_convert_map
+
+        opset = max(
+            (x.version for x in model.opset_import if x.domain == ""),
+            default=1,
+        )
+        convert_map = _get_convert_map(opset)
+        return sorted({n.op_type for n in model.graph.node if n.op_type not in convert_map})
+    except (ImportError, AttributeError):
+        return []
 
 
 def _tvm_worker(model_bytes, inputs, input_names, output_count, result_queue):
@@ -18,6 +43,14 @@ def _tvm_worker(model_bytes, inputs, input_names, output_count, result_queue):
 
     model = onnx.ModelProto()
     model.ParseFromString(model_bytes)
+
+    unsupported = _native_ops_only(model)
+    if unsupported:
+        msg = f"no native TVM converter for: {unsupported}"
+        print(f"[tvm] SKIP {msg}", file=sys.stderr, flush=True)
+        result_queue.put(("error", msg))
+        return
+
     shape_dict = {
         name: np.asarray(inp).shape
         for name, inp in zip(input_names, inputs, strict=True)
@@ -33,7 +66,9 @@ def _tvm_worker(model_bytes, inputs, input_names, output_count, result_queue):
         outputs = [module.get_output(i).numpy() for i in range(output_count)]
         result_queue.put(("ok", outputs))
     except (tvm.TVMError, RuntimeError, ValueError, TypeError, OSError) as e:
-        result_queue.put(("error", str(e)))
+        msg = f"ops={sorted({n.op_type for n in model.graph.node})} error={type(e).__name__}: {e}"
+        print(f"[tvm] SKIP {msg}", file=sys.stderr, flush=True)
+        result_queue.put(("error", msg))
 
 
 class TVMBackendRep(BackendRep):
@@ -58,13 +93,16 @@ class TVMBackendRep(BackendRep):
         if p.is_alive():
             p.terminate()
             p.join()
-            raise BackendIsNotSupposedToImplementIt("tvm process timed out")
+            msg = "tvm process timed out"
+            logger.warning(msg)
+            raise BackendIsNotSupposedToImplementIt(msg)
         if p.exitcode != 0:
-            raise BackendIsNotSupposedToImplementIt(
-                f"tvm process crashed (exit code {p.exitcode})"
-            )
+            msg = f"tvm process crashed (exit code {p.exitcode})"
+            logger.warning(msg)
+            raise BackendIsNotSupposedToImplementIt(msg)
         status, result = q.get_nowait()
         if status == "error":
+            logger.warning("tvm skip: %s", result)
             raise BackendIsNotSupposedToImplementIt(result)
         return result
 

--- a/backends/tvm/backend.py
+++ b/backends/tvm/backend.py
@@ -29,7 +29,8 @@ def _native_ops_only(model):
             default=1,
         )
         convert_map = _get_convert_map(opset)
-        return sorted({n.op_type for n in model.graph.node if n.op_type not in convert_map})
+        unsupported = {n.op_type for n in model.graph.node if n.op_type not in convert_map}
+        return sorted(unsupported)
     except (ImportError, AttributeError):
         return []
 
@@ -66,7 +67,8 @@ def _tvm_worker(model_bytes, inputs, input_names, output_count, result_queue):
         outputs = [module.get_output(i).numpy() for i in range(output_count)]
         result_queue.put(("ok", outputs))
     except (tvm.TVMError, RuntimeError, ValueError, TypeError, OSError) as e:
-        msg = f"ops={sorted({n.op_type for n in model.graph.node})} error={type(e).__name__}: {e}"
+        ops = sorted({n.op_type for n in model.graph.node})
+        msg = f"ops={ops} error={type(e).__name__}: {e}"
         print(f"[tvm] SKIP {msg}", file=sys.stderr, flush=True)
         result_queue.put(("error", msg))
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,11 +15,27 @@ passing and failing tests for the scoreboard.
 import json
 import os
 
+import pytest
+
 from datetime import datetime
 
 
 # Keys for values to save in report (matched with terminalreporter.stats)
 REPORT_KEYS = ["passed", "failed", "skipped"]
+
+# Ops seen across ALL collected test items (populated before -k deselection)
+_suite_ops: set = set()
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(session, config, items):  # noqa: ARG001
+    """Collect all op names from onnx_coverage marks before -k deselection."""
+    for item in items:
+        for mark in item.iter_markers("onnx_coverage"):
+            proto = mark.args[0] if mark.args else None
+            if proto is not None and hasattr(proto, "graph"):
+                for node in proto.graph.node:
+                    _suite_ops.add(node.op_type)
 
 
 def pytest_addoption(parser):
@@ -116,6 +132,7 @@ def _prepare_summary(report, package_versions=None):
 
     summary = {"date": report.get("date", datetime.now().strftime("%m/%d/%Y %H:%M:%S"))}
     summary["versions"] = package_versions
+    summary["total_ops"] = len(_suite_ops)
     for key in report.keys():
         if isinstance(report.get(key), list):
             summary[key] = len(report.get(key))

--- a/website-generator/generator.py
+++ b/website-generator/generator.py
@@ -102,11 +102,19 @@ def mark_coverage(percentage):
             return mark
 
 
-def get_coverage_percentage(trend):
+def get_coverage_percentage(trend, ops=None):
     """Create and return a dict with passed and failed tests percentage.
+
+    When ``total_ops`` is available in the latest trend entry and ``ops`` is
+    provided, the primary ``passed`` score is based on operator coverage
+    (passed_ops / total_ops) rather than raw test counts.  This prevents
+    backends that delegate unsupported ops to a reference runtime from
+    reporting an inflated 100 % score.
 
     :param trend: Trend is a list of report summaries per date.
     :type trend: list
+    :param ops: Operator table from nodes.csv (op name → status string).
+    :type ops: dict or None
     :return: Dictionary with passed and failed tests percentage.
     :rtype: dict
     """
@@ -130,19 +138,42 @@ def get_coverage_percentage(trend):
             + latest_result.get("passed", 0)
             + latest_result.get("skipped", 0)
         )
-        coverage["passed"] = (
+        coverage["tests_passed"] = (
             latest_result.get("passed", 0) / coverage.get("total", 0) * 100
         )
-        coverage["failed"] = (
+        coverage["tests_failed"] = (
             latest_result.get("failed", 0) / coverage.get("total", 0) * 100
         )
-        coverage["skipped"] = (
+        coverage["tests_skipped"] = (
             latest_result.get("skipped", 0) / coverage.get("total", 0) * 100
         )
     except ZeroDivisionError:
+        coverage["tests_passed"] = 0
+        coverage["tests_failed"] = 0
+        coverage["tests_skipped"] = 0
+
+    # Op-level coverage: use when total_ops was captured during the test run.
+    total_ops = latest_result.get("total_ops", 0)
+    ops = ops or {}
+    passed_ops = sum(1 for s in ops.values() if "pass" in s)
+    loaded_ops = len(ops)
+    coverage["passed_ops"] = passed_ops
+    coverage["loaded_ops"] = loaded_ops
+    coverage["total_ops"] = total_ops
+
+    try:
+        if total_ops > 0:
+            # Primary score: fraction of all suite ops that this backend passes
+            coverage["passed"] = passed_ops / total_ops * 100
+        else:
+            # Fallback: use test pass rate when total_ops not yet captured
+            coverage["passed"] = coverage["tests_passed"]
+    except ZeroDivisionError:
         coverage["passed"] = 0
-        coverage["failed"] = 0
-        coverage["skipped"] = 0
+
+    # Retain legacy aliases for templates that reference failed/skipped
+    coverage["failed"] = coverage["tests_failed"]
+    coverage["skipped"] = coverage["tests_skipped"]
 
     coverage["mark"] = mark_coverage(coverage["passed"])
     return coverage
@@ -249,8 +280,8 @@ def prepare_database(config, state="stable"):
         dockerfile_link = backend_config.get("dockerfile_link", "")
         name = backend_config.get("name", backend_id)
         trend = load_trend(results_dir)
-        coverage = get_coverage_percentage(trend)
         ops = load_ops_csv(results_dir)
+        coverage = get_coverage_percentage(trend, ops)
         report = load_report(results_dir)
 
         database[backend_id] = {

--- a/website-generator/resources/src/bar_chart.js
+++ b/website-generator/resources/src/bar_chart.js
@@ -18,6 +18,11 @@
     data: [],
     backgroundColor: palette.failed,
     label: 'Failed'
+  },
+  {
+    data: [],
+    backgroundColor: palette.skipped,
+    label: 'Skipped'
   }];
 
   const trend = backendData.trend;
@@ -25,6 +30,7 @@
   barChartLabels.push(backendData.name);
   barChartDatasets[0].data.push(trend[lastIdx].passed);
   barChartDatasets[1].data.push(trend[lastIdx].failed);
+  barChartDatasets[2].data.push(trend[lastIdx].skipped || 0);
 
   new Chart(barChart, {
     type: 'bar',

--- a/website-generator/resources/src/circle_chart.js
+++ b/website-generator/resources/src/circle_chart.js
@@ -12,12 +12,13 @@
     const trend = database[backend].trend;
     const lastIdx = trend.length - 1;
     const chartData = {
-      labels: ['Passed', 'Failed'],
+      labels: ['Passed', 'Failed', 'Skipped'],
       datasets: [{
-        backgroundColor: [palette.passed, palette.failed],
+        backgroundColor: [palette.passed, palette.failed, palette.skipped],
         borderWidth: 0,
         data: [trend[lastIdx].passed,
-          trend[lastIdx].failed
+          trend[lastIdx].failed,
+          trend[lastIdx].skipped || 0
         ]
       }]
     };

--- a/website-generator/resources/src/main.js
+++ b/website-generator/resources/src/main.js
@@ -5,6 +5,7 @@
 const palette = {
   passed: '#1fa2ff',
   failed: '#c1ddf1',
+  skipped: '#e0e0e0',
   font: '#000000'
 };
 Chart.defaults.global.defaultFontColor = palette.font;

--- a/website-generator/templates-module/templates/score_table_details.html
+++ b/website-generator/templates-module/templates/score_table_details.html
@@ -41,6 +41,9 @@
             <div class="centered">
                  <div class='{{backend_data.coverage.mark}}'>
                     {{ "{:,.2f}%".format(backend_data.coverage.passed) }}
+                    {% if backend_data.coverage.total_ops > 0 %}
+                    <br><small>{{ backend_data.coverage.passed_ops }}/{{ backend_data.coverage.total_ops }} ops</small>
+                    {% endif %}
                 </div>
             </div>
         </td>

--- a/website-generator/templates-module/templates/score_table_home.html
+++ b/website-generator/templates-module/templates/score_table_home.html
@@ -30,6 +30,9 @@
             <div class="centered">
                  <div class='{{backend_data.coverage.mark}}'>
                     {{ "{:,.2f}%".format(backend_data.coverage.passed) }}
+                    {% if backend_data.coverage.total_ops > 0 %}
+                    <br><small>{{ backend_data.coverage.passed_ops }}/{{ backend_data.coverage.total_ops }} ops</small>
+                    {% endif %}
                 </div>
             </div>
         </td>


### PR DESCRIPTION
Done. Summary of changes:

backends/tvm/backend.py — Added _native_ops_only() which checks TVM's internal _get_convert_map before compilation. Any op without a native Relay converter is rejected with BackendIsNotSupposedToImplementIt instead of silently falling back to ONNX. Ops that get skipped print [tvm] SKIP no native TVM converter for: ['Bernoulli', 'Cast', ...] to stderr.

test/conftest.py — Added a tryfirst pytest_collection_modifyitems hook that collects all op names from onnx_coverage marks before the -k not _cuda filter is applied, giving the true total suite op count. This is saved as total_ops in every trend entry.

website-generator/generator.py — get_coverage_percentage now uses passed_ops / total_ops as the primary score when total_ops > 0, falling back to the old test pass rate for historical data. ORT would go from ~84% test rate → ~84% op coverage (close), TVM would go from 100% → real native coverage (~70-80% expected).

Templates — Score cell now shows 84.12% + 186/221 ops so the op denominator is always visible.