### PR TITLE
Fix lint pipeline failures

### DIFF
--- a/backends/tvm/backend.py
+++ b/backends/tvm/backend.py
@@ -29,7 +29,9 @@ def _native_ops_only(model):
             default=1,
         )
         convert_map = _get_convert_map(opset)
-        unsupported = {n.op_type for n in model.graph.node if n.op_type not in convert_map}
+        unsupported = {
+            n.op_type for n in model.graph.node if n.op_type not in convert_map
+        }
         return sorted(unsupported)
     except (ImportError, AttributeError):
         return []

--- a/website-generator/resources/src/bar_chart.js
+++ b/website-generator/resources/src/bar_chart.js
@@ -32,7 +32,7 @@
   barChartDatasets[1].data.push(trend[lastIdx].failed);
   barChartDatasets[2].data.push(trend[lastIdx].skipped || 0);
 
-  new Chart(barChart, {
+  barChart._chart = new Chart(barChart, {
     type: 'bar',
     data: {
       labels: barChartLabels,

--- a/website-generator/resources/src/circle_chart.js
+++ b/website-generator/resources/src/circle_chart.js
@@ -23,7 +23,7 @@
       }]
     };
 
-    new Chart(circleChart, {
+    circleChart._chart = new Chart(circleChart, {
       type: 'doughnut',
       data: chartData,
       options: {

--- a/website-generator/resources/src/line_chart.js
+++ b/website-generator/resources/src/line_chart.js
@@ -51,7 +51,7 @@
     }]
   };
 
-  new Chart(lineTrend, {
+  lineTrend._chart = new Chart(lineTrend, {
     type: 'line',
     data: lineChartData,
     options: {


### PR DESCRIPTION
- fix the Ruff line-length violation in the TVM backend helper
- remove ESLint `no-new` warnings in the website chart scripts by storing created Chart instances
- restore a clean lint pipeline for both Python and frontend checks