### PR TITLE
Improve scoreboard date display

### DIFF
--- a/website-generator/resources/css/base.css
+++ b/website-generator/resources/css/base.css
@@ -89,8 +89,6 @@ hr {
 }
 
 .backend-summary {
-    min-width: 220px;
-    max-width: 320px;
     height: 80pt;
     display: flex;
     align-items: center;
@@ -128,6 +126,24 @@ hr {
 
 .backend-meta-link-row {
     margin-bottom: 0;
+}
+
+.centered-date {
+    line-height: 1.35;
+    overflow: visible;
+}
+
+.centered-date [data-utc-datetime] {
+    display: inline-block;
+    white-space: nowrap;
+}
+
+.score-cell {
+    justify-content: flex-end;
+    text-align: right;
+    padding-left: 20pt;
+    padding-right: 8px;
+    overflow: visible;
 }
 
 .nav-tabs .nav-item .nav-link {

--- a/website-generator/resources/src/main.js
+++ b/website-generator/resources/src/main.js
@@ -9,3 +9,97 @@ const palette = {
   font: '#000000'
 };
 Chart.defaults.global.defaultFontColor = palette.font;
+
+window.parseScoreboardUtcDate = function (value) {
+  if (!value) {
+    return null;
+  }
+
+  const match = value.match(
+    /^(\d{2})\/(\d{2})\/(\d{4}) (\d{2}):(\d{2}):(\d{2})$/
+  );
+  if (!match) {
+    return null;
+  }
+
+  const [, month, day, year, hour, minute, second] = match;
+  return new Date(Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second)
+  ));
+};
+
+window.formatScoreboardDate = function (value, includeTime) {
+  const date = window.parseScoreboardUtcDate(value);
+  if (!date) {
+    return value;
+  }
+
+  const formatOptions = includeTime
+    ? {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit'
+      }
+    : {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+      };
+
+  return new Intl.DateTimeFormat(undefined, formatOptions).format(date);
+};
+
+window.formatScoreboardDateParts = function (value) {
+  const date = window.parseScoreboardUtcDate(value);
+  if (!date) {
+    return null;
+  }
+
+  return {
+    date: new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+    }).format(date),
+    time: new Intl.DateTimeFormat(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit'
+    }).format(date)
+  };
+};
+
+document.addEventListener('DOMContentLoaded', function () {
+  const dateNodes = document.querySelectorAll('[data-utc-datetime]');
+
+  dateNodes.forEach(node => {
+    const utcValue = node.getAttribute('data-utc-datetime');
+    const formatted = window.formatScoreboardDateParts(utcValue);
+
+    if (formatted) {
+      node.textContent = '';
+
+      const dateSpan = document.createElement('span');
+      dateSpan.textContent = formatted.date;
+
+      const timeSpan = document.createElement('span');
+      timeSpan.textContent = formatted.time;
+
+      node.appendChild(dateSpan);
+      node.appendChild(document.createElement('br'));
+      node.appendChild(timeSpan);
+    } else {
+      node.textContent = window.formatScoreboardDate(utcValue, true);
+    }
+
+    node.setAttribute('title', utcValue + ' UTC');
+  });
+});

--- a/website-generator/templates-module/templates/score_table_details.html
+++ b/website-generator/templates-module/templates/score_table_details.html
@@ -33,12 +33,12 @@
             </td>
         {% endif %}
         <td>
-            <div class="centered">
-              {{ backend_data.trend[-1].date }}
+            <div class="centered centered-date">
+              <span data-utc-datetime="{{ backend_data.trend[-1].date }}">{{ backend_data.trend[-1].date }} UTC</span>
             </div>
         </td>
         <td>
-            <div class="centered">
+            <div class="centered score-cell">
                  <div class='{{backend_data.coverage.mark}}'>
                     {{ "{:,.2f}%".format(backend_data.coverage.passed) }}
                     {% if backend_data.coverage.total_ops > 0 %}

--- a/website-generator/templates-module/templates/score_table_home.html
+++ b/website-generator/templates-module/templates/score_table_home.html
@@ -26,12 +26,12 @@
             </div>
         </td>
         <td>
-            <div class="centered">
-              {{ backend_data.trend[-1].date }}
+            <div class="centered centered-date">
+              <span data-utc-datetime="{{ backend_data.trend[-1].date }}">{{ backend_data.trend[-1].date }} UTC</span>
             </div>
         </td>
         <td>
-            <div class="centered">
+            <div class="centered score-cell">
                  <div class='{{backend_data.coverage.mark}}'>
                     {{ "{:,.2f}%".format(backend_data.coverage.passed) }}
                     {% if backend_data.coverage.total_ops > 0 %}


### PR DESCRIPTION
This PR improves how scoreboard timestamps are shown in the generated website.

It updates the date display in the overview and detail tables so that:
- timestamps are interpreted as UTC
- they are rendered in the viewer's local time
- date and time are shown on separate lines
- the score cell layout is adjusted for better readability