### PR TITLE
Fixed trend collection by centralize trend merging in collect job

### DIFF
--- a/.github/workflows/benchmark-backends.yml
+++ b/.github/workflows/benchmark-backends.yml
@@ -282,6 +282,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
       - name: Switch to benchmark-results branch
         run: |
           git config --global user.name "GitHub Action"
@@ -359,6 +364,9 @@ jobs:
         with:
           name: results-tvm-stable
           path: results/tvm/stable/
+
+      - name: Merge trend history
+        run: python3 scripts/merge_trends.py --config ./setup/config.json --base-ref HEAD
 
       - name: Deploy results
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Developer scripts for test only
-scripts/
+scripts/*
+!scripts/merge_trends.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/scripts/merge_trends.py
+++ b/scripts/merge_trends.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Merge benchmark trend histories centrally in the collect job."""
+
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+
+from argparse import ArgumentParser
+from datetime import datetime
+from pathlib import Path
+
+
+REPORT_KEYS = ["passed", "failed", "skipped"]
+
+
+def load_json_file(file_path, default):
+    """Load JSON from a file and return a default value on failure."""
+    try:
+        with open(file_path, "r") as json_file:
+            return json.load(json_file)
+    except (IOError, json.decoder.JSONDecodeError):
+        return default
+
+
+def load_config(file_path):
+    """Load the scoreboard configuration."""
+    return load_json_file(file_path, {})
+
+
+def load_json_from_git(base_ref, file_path):
+    """Load JSON from a file stored in git at the specified ref."""
+    relative_path = file_path.as_posix()
+    command = ["git", "show", f"{base_ref}:{relative_path}"]
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        return []
+
+    try:
+        return json.loads(result.stdout)
+    except json.decoder.JSONDecodeError:
+        return []
+
+
+def filter_packages(package_versions, backend_config):
+    """Filter package versions down to the backend core packages."""
+    core_packages = ["onnx", *backend_config.get("core_packages", [])]
+    return [
+        package for package in package_versions if package.get("name") in core_packages
+    ]
+
+
+def count_total_ops(results_dir):
+    """Count unique ops from nodes.csv for the current run."""
+    try:
+        with open(results_dir / "nodes.csv", newline="") as csv_file:
+            reader = csv.DictReader(csv_file)
+            return len({row.get("Op") for row in reader if row.get("Op")})
+    except IOError:
+        return 0
+
+
+def build_summary(results_dir, backend_config):
+    """Build a trend summary for the current benchmark artifact."""
+    report = load_json_file(results_dir / "report.json", {})
+    if not report:
+        return None
+
+    package_versions = load_json_file(results_dir / "pip-list.json", [])
+    summary = {
+        "date": report.get("date", datetime.now().strftime("%m/%d/%Y %H:%M:%S")),
+        "versions": filter_packages(package_versions, backend_config),
+        "total_ops": count_total_ops(results_dir),
+    }
+    for key in REPORT_KEYS:
+        report_group = report.get(key, [])
+        summary[key] = len(report_group) if isinstance(report_group, list) else 0
+    return summary
+
+
+def merge_trend(summary, trend):
+    """Merge the current summary into the existing trend history."""
+    if summary is None:
+        return trend
+
+    min_length = 2
+    valid_length = len(trend) >= min_length and (
+        len(summary.keys()) == len(trend[-1].keys())
+    )
+    equal_values = trend and all(
+        summary.get(key) == trend[-1].get(key)
+        for key in summary.keys()
+        if key != "date"
+    )
+    if valid_length and equal_values:
+        trend[-1] = summary
+    else:
+        trend.append(summary)
+    return trend
+
+
+def merge_backend_trend(base_ref, results_dir, backend_config):
+    """Merge one backend results directory with the historical trend."""
+    existing_trend = load_json_from_git(base_ref, results_dir / "trend.json")
+    current_summary = build_summary(results_dir, backend_config)
+    merged_trend = merge_trend(current_summary, existing_trend)
+
+    results_dir.mkdir(parents=True, exist_ok=True)
+    with open(results_dir / "trend.json", "w") as trend_file:
+        json.dump(merged_trend, trend_file, sort_keys=True, indent=4)
+
+
+def iter_backends(config):
+    """Yield all backend configurations and their results directories."""
+    for state in ("stable", "development"):
+        for backend_config in config.get(state, {}).values():
+            yield Path(backend_config.get("results_dir", "")), backend_config
+
+
+def main():
+    """Run the central trend merge for all configured backends."""
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default="./setup/config.json",
+        help="Path to the scoreboard config file",
+        type=str,
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="HEAD",
+        help="Git ref providing the previous trend history",
+        type=str,
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    for results_dir, backend_config in iter_backends(config):
+        if not str(results_dir):
+            continue
+        merge_backend_trend(args.base_ref, results_dir, backend_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_merge_trends.py
+++ b/test/test_merge_trends.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for central trend merging."""
+
+import json
+
+from pathlib import Path
+
+from scripts.merge_trends import build_summary, merge_trend
+
+
+def test_build_summary_uses_report_and_core_packages(tmp_path):
+    """Build summary from report and pip list artifacts."""
+    results_dir = Path(tmp_path)
+    report = {
+        "date": "03/25/2026 00:50:48",
+        "failed": ["f1", "f2"],
+        "passed": ["p1", "p2", "p3"],
+        "skipped": ["s1"],
+    }
+    package_versions = [
+        {"name": "onnx", "version": "1.20.1"},
+        {"name": "onnxruntime", "version": "1.22.0"},
+        {"name": "numpy", "version": "2.0.0"},
+    ]
+    nodes_csv = "Op,None\nAdd,Passed!\nMul,Failed!\nMul,Passed!\n"
+    (results_dir / "report.json").write_text(json.dumps(report))
+    (results_dir / "pip-list.json").write_text(json.dumps(package_versions))
+    (results_dir / "nodes.csv").write_text(nodes_csv)
+
+    summary = build_summary(results_dir, {"core_packages": ["onnxruntime"]})
+
+    assert summary == {
+        "date": "03/25/2026 00:50:48",
+        "failed": 2,
+        "passed": 3,
+        "skipped": 1,
+        "total_ops": 2,
+        "versions": [
+            {"name": "onnx", "version": "1.20.1"},
+            {"name": "onnxruntime", "version": "1.22.0"},
+        ],
+    }
+
+
+def test_merge_trend_appends_new_summary():
+    """Append a changed summary to the existing trend."""
+    previous_trend = [
+        {
+            "date": "03/24/2026 00:50:48",
+            "failed": 1,
+            "passed": 3,
+            "skipped": 0,
+            "total_ops": 10,
+            "versions": [{"name": "onnx", "version": "1.20.1"}],
+        }
+    ]
+    summary = {
+        "date": "03/25/2026 00:50:48",
+        "failed": 2,
+        "passed": 3,
+        "skipped": 0,
+        "total_ops": 10,
+        "versions": [{"name": "onnx", "version": "1.20.1"}],
+    }
+
+    merged = merge_trend(summary, previous_trend)
+
+    assert len(merged) == 2
+    assert merged[-1] == summary
+
+
+def test_merge_trend_replaces_last_identical_summary():
+    """Retain the existing identical-summary replacement behavior."""
+    previous_trend = [
+        {
+            "date": "03/23/2026 00:50:48",
+            "failed": 1,
+            "passed": 3,
+            "skipped": 0,
+            "total_ops": 10,
+            "versions": [{"name": "onnx", "version": "1.20.1"}],
+        },
+        {
+            "date": "03/24/2026 00:50:48",
+            "failed": 1,
+            "passed": 3,
+            "skipped": 0,
+            "total_ops": 10,
+            "versions": [{"name": "onnx", "version": "1.20.1"}],
+        },
+    ]
+    summary = {
+        "date": "03/25/2026 00:50:48",
+        "failed": 1,
+        "passed": 3,
+        "skipped": 0,
+        "total_ops": 10,
+        "versions": [{"name": "onnx", "version": "1.20.1"}],
+    }
+
+    merged = merge_trend(summary, previous_trend)
+
+    assert len(merged) == 2
+    assert merged[-1]["date"] == "03/25/2026 00:50:48"


### PR DESCRIPTION
I asked codex to fix the problem that trend history is currently not recorded, e.g. https://onnx.ai/backend-scoreboard/emx-onnx-cgen_details_stable.html

I don't know how to test it locally, so I would give it a try on the live system...

## Summary
- move trend history merging into the collect job so history is rebuilt from benchmark-results before commit
- add a merge script that derives the current summary from report.json, pip-list.json, and nodes.csv without relying on artifact trend.json
- add focused tests for summary construction and trend merge behavior