### PR TITLE
Align website score with trend and split supported ops column

### DIFF
--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for website generator coverage calculations."""
+
+import importlib.util
+
+from pathlib import Path
+
+
+GENERATOR_PATH = (
+    Path(__file__).resolve().parent.parent / "website-generator" / "generator.py"
+)
+SPEC = importlib.util.spec_from_file_location("scoreboard_generator", GENERATOR_PATH)
+GENERATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(GENERATOR)
+
+
+def test_coverage_score_uses_test_pass_rate_even_with_total_ops():
+    """Keep the overview score aligned with the trend's unit test percentage."""
+    trend = [
+        {
+            "date": "04/01/2026 00:59:17",
+            "passed": 482,
+            "failed": 141,
+            "skipped": 814,
+            "total_ops": 194,
+        }
+    ]
+    ops = {"Add": "passed", "Mul": "passed", "Sub": "failed"}
+
+    coverage = GENERATOR.get_coverage_percentage(trend, ops)
+
+    assert round(coverage["tests_passed"], 2) == 33.54
+    assert round(coverage["passed"], 2) == 33.54
+    assert coverage["passed_ops"] == 2
+    assert coverage["total_ops"] == 194
+
+
+def test_load_ops_csv_ignores_summary_row(tmp_path):
+    """Ignore the synthetic Summary row in nodes.csv."""
+    csv_content = "\n".join(
+        [
+            "Op,None",
+            "Add,Passed!",
+            "Mul,Failed!",
+            "Summary,105/193 node tests passed",
+        ]
+    )
+    (tmp_path / "nodes.csv").write_text(csv_content)
+
+    ops = GENERATOR.load_ops_csv(tmp_path)
+
+    assert list(ops.keys()) == ["Add", "Mul"]
+    assert ops["Add"] == "passed"
+    assert ops["Mul"] == "failed"
+
+
+def test_load_ops_summary_reads_summary_row(tmp_path):
+    """Expose the synthetic Summary row separately from operator coverage."""
+    csv_content = "\n".join(
+        [
+            "Op,None",
+            "Add,Passed!",
+            "Summary,105/193 node tests passed",
+        ]
+    )
+    (tmp_path / "nodes.csv").write_text(csv_content)
+
+    summary = GENERATOR.load_ops_summary(tmp_path)
+
+    assert summary == "105/193 node tests passed"

--- a/website-generator/generator.py
+++ b/website-generator/generator.py
@@ -105,11 +105,9 @@ def mark_coverage(percentage):
 def get_coverage_percentage(trend, ops=None):
     """Create and return a dict with passed and failed tests percentage.
 
-    When ``total_ops`` is available in the latest trend entry and ``ops`` is
-    provided, the primary ``passed`` score is based on operator coverage
-    (passed_ops / total_ops) rather than raw test counts.  This prevents
-    backends that delegate unsupported ops to a reference runtime from
-    reporting an inflated 100 % score.
+    The primary ``passed`` score is based on unit test results so the summary
+    score matches the trend chart. Operator coverage is still exposed as
+    auxiliary metadata via ``passed_ops`` and ``total_ops``.
 
     :param trend: Trend is a list of report summaries per date.
     :type trend: list
@@ -161,15 +159,7 @@ def get_coverage_percentage(trend, ops=None):
     coverage["loaded_ops"] = loaded_ops
     coverage["total_ops"] = total_ops
 
-    try:
-        if total_ops > 0:
-            # Primary score: fraction of all suite ops that this backend passes
-            coverage["passed"] = passed_ops / total_ops * 100
-        else:
-            # Fallback: use test pass rate when total_ops not yet captured
-            coverage["passed"] = coverage["tests_passed"]
-    except ZeroDivisionError:
-        coverage["passed"] = 0
+    coverage["passed"] = coverage["tests_passed"]
 
     # Retain legacy aliases for templates that reference failed/skipped
     coverage["failed"] = coverage["tests_failed"]
@@ -197,10 +187,26 @@ def load_ops_csv(file_dir, file_name="nodes.csv"):
         with open(os.path.join(file_dir, file_name), newline="") as csv_file:
             reader = csv.DictReader(csv_file)
             for row in reader:
-                ops_table[row["Op"]] = row.get("None", "").replace("!", "").lower()
+                op_name = row.get("Op")
+                if not op_name or op_name == "Summary":
+                    continue
+                ops_table[op_name] = row.get("None", "").replace("!", "").lower()
     except IOError:
         pass  # Return empty dict
     return ops_table
+
+
+def load_ops_summary(file_dir, file_name="nodes.csv"):
+    """Load the synthetic Summary entry from the operators coverage CSV."""
+    try:
+        with open(os.path.join(file_dir, file_name), newline="") as csv_file:
+            reader = csv.DictReader(csv_file)
+            for row in reader:
+                if row.get("Op") == "Summary":
+                    return row.get("None", "").replace("!", "")
+    except IOError:
+        pass
+    return ""
 
 
 def load_report(file_dir, file_name="report.json"):
@@ -284,6 +290,7 @@ def prepare_database(config, state="stable"):
         long_description = backend_config.get("long_description", "")
         trend = load_trend(results_dir)
         ops = load_ops_csv(results_dir)
+        ops_summary = load_ops_summary(results_dir)
         coverage = get_coverage_percentage(trend, ops)
         report = load_report(results_dir)
 
@@ -295,6 +302,7 @@ def prepare_database(config, state="stable"):
             "trend": trend,
             "coverage": coverage,
             "ops": ops,
+            "ops_summary": ops_summary,
             "report": report,
             "dockerfile_link": repo_url + dockerfile_link,
         }

--- a/website-generator/resources/css/base.css
+++ b/website-generator/resources/css/base.css
@@ -146,6 +146,26 @@ hr {
     overflow: visible;
 }
 
+.supported-ops-cell {
+    justify-content: flex-end;
+    text-align: right;
+    overflow: visible;
+}
+
+.supported-ops-value {
+    color: #1fa2ff;
+    font-size: 30pt;
+    white-space: nowrap;
+}
+
+.ops-summary {
+    margin-top: 12px;
+    color: #0071bc;
+    font-size: 12pt;
+    font-weight: 600;
+    text-align: left;
+}
+
 .nav-tabs .nav-item .nav-link {
     border-bottom: 0px;
     background-color: transparent;

--- a/website-generator/templates-module/templates/score_table_details.html
+++ b/website-generator/templates-module/templates/score_table_details.html
@@ -7,6 +7,7 @@
         {% endif %}
         <th scope="row">Date</th>
         <th scope="row">Score</th>
+        <th scope="row">Supported Ops</th>
     </tr>
     <tr>
         <th scope="row">
@@ -41,10 +42,16 @@
             <div class="centered score-cell">
                  <div class='{{backend_data.coverage.mark}}'>
                     {{ "{:,.2f}%".format(backend_data.coverage.passed) }}
-                    {% if backend_data.coverage.total_ops > 0 %}
-                    <br><small>{{ backend_data.coverage.passed_ops }}/{{ backend_data.coverage.total_ops }} ops</small>
-                    {% endif %}
                 </div>
+            </div>
+        </td>
+        <td>
+            <div class="centered supported-ops-cell">
+                {% if backend_data.coverage.total_ops > 0 %}
+                    <div class="supported-ops-value">{{ backend_data.coverage.passed_ops }}/{{ backend_data.coverage.total_ops }}</div>
+                {% else %}
+                    <div class="supported-ops-value">-</div>
+                {% endif %}
             </div>
         </td>
     </tr>

--- a/website-generator/templates-module/templates/score_table_home.html
+++ b/website-generator/templates-module/templates/score_table_home.html
@@ -5,6 +5,7 @@
         <th scope="row">Date</th>
         <th scope="row">Score</th>
         <th scope="row">Coverage</th>
+        <th scope="row">Supported Ops</th>
         <th scope="row">Details</th>
     </tr>
     {% for backend, backend_data in database.items() %}
@@ -34,9 +35,6 @@
             <div class="centered score-cell">
                  <div class='{{backend_data.coverage.mark}}'>
                     {{ "{:,.2f}%".format(backend_data.coverage.passed) }}
-                    {% if backend_data.coverage.total_ops > 0 %}
-                    <br><small>{{ backend_data.coverage.passed_ops }}/{{ backend_data.coverage.total_ops }} ops</small>
-                    {% endif %}
                 </div>
             </div>
         </td>
@@ -45,6 +43,15 @@
                 <div>
                     <canvas width="100" height="60" id='circle_{{ backend_data.name }}'></canvas>
                 </div>
+            </div>
+        </td>
+        <td>
+            <div class="centered supported-ops-cell">
+                {% if backend_data.coverage.total_ops > 0 %}
+                    <div class="supported-ops-value">{{ backend_data.coverage.passed_ops }}/{{ backend_data.coverage.total_ops }}</div>
+                {% else %}
+                    <div class="supported-ops-value">-</div>
+                {% endif %}
             </div>
         </td>
         <td>

--- a/website-generator/templates-module/templates/table_tabs.html
+++ b/website-generator/templates-module/templates/table_tabs.html
@@ -53,6 +53,11 @@
             <div class="row justify-content-center">
                 <div class="col-auto">
                     {%include "ops_table.html" %}
+                    {% for backend, data in database.items() %}
+                        {% if data.ops_summary %}
+                            <p class="ops-summary"><strong>{{ data.name }}:</strong> {{ data.ops_summary }}</p>
+                        {% endif %}
+                    {% endfor %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- fix score in backend overview
- move supported ops into a dedicated column
