### PR TITLE
Generate ops.json from ONNX coverage markers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/scripts/merge_trends.py
+++ b/scripts/merge_trends.py
@@ -16,6 +16,21 @@ from pathlib import Path
 REPORT_KEYS = ["passed", "failed", "skipped"]
 
 
+def count_total_ops_from_ops_json(results_dir):
+    """Count unique ops from ops.json for the current run."""
+    ops = load_json_file(results_dir / "ops.json", [])
+    if not isinstance(ops, list):
+        return 0
+
+    return len(
+        {
+            ((entry.get("domain") or ""), entry.get("op_type"))
+            for entry in ops
+            if isinstance(entry, dict) and entry.get("op_type")
+        }
+    )
+
+
 def load_json_file(file_path, default):
     """Load JSON from a file and return a default value on failure."""
     try:
@@ -53,11 +68,15 @@ def filter_packages(package_versions, backend_config):
 
 
 def count_total_ops(results_dir):
-    """Count unique ops from nodes.csv for the current run."""
+    """Count unique ops from ops.json, falling back to nodes.csv."""
+    total_ops = count_total_ops_from_ops_json(results_dir)
+    if total_ops:
+        return total_ops
+
     try:
         with open(results_dir / "nodes.csv", newline="") as csv_file:
             reader = csv.DictReader(csv_file)
-            return len({row.get("Op") for row in reader if row.get("Op")})
+            return len({row.get("Op") for row in reader if row.get("Op") != "Summary"})
     except IOError:
         return 0
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -24,18 +24,90 @@ from datetime import datetime
 REPORT_KEYS = ["passed", "failed", "skipped"]
 
 # Ops seen across ALL collected test items (populated before -k deselection)
-_suite_ops: set = set()
+_suite_ops: set[tuple[str, str]] = set()
+_test_proto_refs: dict[str, object] = {}
+
+
+def _normalize_op_domain(node):
+    """Return the normalized ONNX domain for a collected node."""
+    return getattr(node, "domain", "") or ""
+
+
+def _normalize_record_name(nodeid):
+    """Remove the python file name from a pytest node id."""
+    split_id = nodeid.split("::")
+    clear_id = filter(lambda x: ".py" not in x, split_id)
+    return "::".join(clear_id)
+
+
+def _extract_ops_from_proto(proto):
+    """Extract unique ops from an ONNX model proto."""
+    if proto is None or not hasattr(proto, "graph"):
+        return set()
+    return {
+        (_normalize_op_domain(node), node.op_type)
+        for node in getattr(proto.graph, "node", [])
+    }
+
+
+def _extract_ops_from_proto_ref(proto_ref):
+    """Resolve ONNX's mutable proto reference and extract its ops."""
+    if isinstance(proto_ref, list):
+        if len(proto_ref) != 1:
+            return set()
+        proto_ref = proto_ref[0]
+    return _extract_ops_from_proto(proto_ref)
+
+
+def _prepare_ops(report):
+    """Return collected operators enriched with per-status test counts."""
+    _suite_ops.clear()
+    ops_table = {}
+
+    for proto_ref in _test_proto_refs.values():
+        for op_key in _extract_ops_from_proto_ref(proto_ref):
+            _suite_ops.add(op_key)
+            ops_table.setdefault(
+                op_key,
+                {
+                    "domain": op_key[0],
+                    "op_type": op_key[1],
+                    "total_tests": 0,
+                    "passed_tests": 0,
+                    "failed_tests": 0,
+                    "skipped_tests": 0,
+                },
+            )
+
+    for status in REPORT_KEYS:
+        for test_name in report.get(status, []):
+            for op_key in _extract_ops_from_proto_ref(_test_proto_refs.get(test_name)):
+                _suite_ops.add(op_key)
+                op_entry = ops_table.setdefault(
+                    op_key,
+                    {
+                        "domain": op_key[0],
+                        "op_type": op_key[1],
+                        "total_tests": 0,
+                        "passed_tests": 0,
+                        "failed_tests": 0,
+                        "skipped_tests": 0,
+                    },
+                )
+                op_entry["total_tests"] += 1
+                op_entry[f"{status}_tests"] += 1
+
+    return [ops_table[op_key] for op_key in sorted(ops_table)]
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(session, config, items):  # noqa: ARG001
-    """Collect all op names from onnx_coverage marks before -k deselection."""
+    """Collect ONNX proto references from coverage marks before deselection."""
+    _test_proto_refs.clear()
     for item in items:
-        for mark in item.iter_markers("onnx_coverage"):
-            proto = mark.args[0] if mark.args else None
-            if proto is not None and hasattr(proto, "graph"):
-                for node in proto.graph.node:
-                    _suite_ops.add(node.op_type)
+        mark = item.get_closest_marker("onnx_coverage")
+        if mark is not None and mark.args:
+            _test_proto_refs[_normalize_record_name(item.nodeid)] = mark.args[0]
 
 
 def pytest_addoption(parser):
@@ -61,6 +133,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     # Collect and save the results
     report = _prepare_report(terminalreporter.stats)
     _save_report(report, results_dir)
+    _save_ops(_prepare_ops(report), results_dir)
     package_versions = _load_versions(results_dir)
     scoreboard_config = _load_scoreboard_config("/root/setup/config.json")
     core_package_versions = _filter_packages(package_versions, scoreboard_config)
@@ -89,10 +162,7 @@ def _prepare_report(stats):
         report[key] = []
         for record in stats_group:
             if hasattr(record, "nodeid"):
-                # Remove file name from test id
-                split_id = record.nodeid.split("::")
-                clear_id = filter(lambda x: ".py" not in x, split_id)
-                record_name = "::".join(clear_id)
+                record_name = _normalize_record_name(record.nodeid)
                 report[key].append(record_name)
         report[key].sort()
     return report
@@ -151,6 +221,12 @@ def _save_report(report, results_dir, file_name="report.json"):
     """
     with open(os.path.join(results_dir, file_name), "w") as report_file:
         json.dump(report, report_file, sort_keys=True, indent=4)
+
+
+def _save_ops(ops, results_dir, file_name="ops.json"):
+    """Save the collected operators to the json file."""
+    with open(os.path.join(results_dir, file_name), "w") as ops_file:
+        json.dump(ops, ops_file, sort_keys=True, indent=4)
 
 
 def _save_trend(trend, results_dir, file_name="trend.json"):

--- a/test/test_conftest_ops.py
+++ b/test/test_conftest_ops.py
@@ -35,9 +35,7 @@ def test_prepare_ops_preserves_domain_and_adds_counts():
 
     CONFTEST._test_proto_refs.update(
         {
-            "OnnxBackendNodeModelTest::test_add_cpu": [
-                Model([Node("", "Add")])
-            ],
+            "OnnxBackendNodeModelTest::test_add_cpu": [Model([Node("", "Add")])],
             "OnnxBackendNodeModelTest::test_ml_cpu": [
                 Model([Node("", "Add"), Node("ai.onnx.ml", "ArrayFeatureExtractor")])
             ],
@@ -102,9 +100,7 @@ def test_extract_ops_from_proto_ref_uses_mutable_onnx_mark_payload():
         def __init__(self, nodes):
             self.graph = Graph(nodes)
 
-    proto_ref = [
-        Model([Node("", "Add"), Node("ai.onnx.ml", "ArrayFeatureExtractor")])
-    ]
+    proto_ref = [Model([Node("", "Add"), Node("ai.onnx.ml", "ArrayFeatureExtractor")])]
 
     assert CONFTEST._extract_ops_from_proto_ref(proto_ref) == {
         ("", "Add"),

--- a/test/test_conftest_ops.py
+++ b/test/test_conftest_ops.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for operator artifact generation in pytest reporting hooks."""
+
+import importlib.util
+
+from pathlib import Path
+
+
+CONFTEST_PATH = Path(__file__).resolve().parent / "conftest.py"
+SPEC = importlib.util.spec_from_file_location("scoreboard_pytest_conftest", CONFTEST_PATH)
+CONFTEST = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CONFTEST)
+
+
+def test_prepare_ops_preserves_domain_and_adds_counts():
+    """Serialize unique domain/op_type pairs with per-status test counts."""
+    CONFTEST._suite_ops.clear()
+    CONFTEST._test_proto_refs.clear()
+
+    class Node:
+        def __init__(self, domain, op_type):
+            self.domain = domain
+            self.op_type = op_type
+
+    class Graph:
+        def __init__(self, nodes):
+            self.node = nodes
+
+    class Model:
+        def __init__(self, nodes):
+            self.graph = Graph(nodes)
+
+    CONFTEST._test_proto_refs.update(
+        {
+            "OnnxBackendNodeModelTest::test_add_cpu": [
+                Model([Node("", "Add")])
+            ],
+            "OnnxBackendNodeModelTest::test_ml_cpu": [
+                Model([Node("", "Add"), Node("ai.onnx.ml", "ArrayFeatureExtractor")])
+            ],
+            "OnnxBackendNodeModelTest::test_ml_skip_cpu": [
+                Model([Node("ai.onnx.ml", "ArrayFeatureExtractor")])
+            ],
+        }
+    )
+
+    report = {
+        "passed": [
+            "OnnxBackendNodeModelTest::test_add_cpu",
+            "OnnxBackendNodeModelTest::test_ml_cpu",
+        ],
+        "failed": [],
+        "skipped": ["OnnxBackendNodeModelTest::test_ml_skip_cpu"],
+    }
+
+    assert CONFTEST._prepare_ops(report) == [
+        {
+            "domain": "",
+            "op_type": "Add",
+            "total_tests": 2,
+            "passed_tests": 2,
+            "failed_tests": 0,
+            "skipped_tests": 0,
+        },
+        {
+            "domain": "ai.onnx.ml",
+            "op_type": "ArrayFeatureExtractor",
+            "total_tests": 2,
+            "passed_tests": 1,
+            "failed_tests": 0,
+            "skipped_tests": 1,
+        },
+    ]
+
+
+def test_normalize_record_name_removes_python_file_prefix():
+    """Use the same normalized node id in report and ops mappings."""
+    assert (
+        CONFTEST._normalize_record_name(
+            "test/test_backend.py::OnnxBackendNodeModelTest::test_add_cpu"
+        )
+        == "OnnxBackendNodeModelTest::test_add_cpu"
+    )
+
+
+def test_extract_ops_from_proto_ref_uses_mutable_onnx_mark_payload():
+    """Read operator metadata from ONNX's mutable proto reference."""
+
+    class Node:
+        def __init__(self, domain, op_type):
+            self.domain = domain
+            self.op_type = op_type
+
+    class Graph:
+        def __init__(self, nodes):
+            self.node = nodes
+
+    class Model:
+        def __init__(self, nodes):
+            self.graph = Graph(nodes)
+
+    proto_ref = [
+        Model([Node("", "Add"), Node("ai.onnx.ml", "ArrayFeatureExtractor")])
+    ]
+
+    assert CONFTEST._extract_ops_from_proto_ref(proto_ref) == {
+        ("", "Add"),
+        ("ai.onnx.ml", "ArrayFeatureExtractor"),
+    }
+
+
+def test_collection_uses_onnx_coverage_mark_proto_refs():
+    """Store the ONNX coverage marker payload by normalized node id."""
+
+    class Mark:
+        def __init__(self, args):
+            self.args = args
+
+    class Item:
+        def __init__(self, nodeid, mark):
+            self.nodeid = nodeid
+            self._mark = mark
+
+        def get_closest_marker(self, name):
+            if name == "onnx_coverage":
+                return self._mark
+            return None
+
+    proto_ref = [object()]
+    item = Item(
+        "test/test_backend.py::OnnxBackendNodeModelTest::test_add_cpu",
+        Mark((proto_ref, "NodeModel")),
+    )
+
+    CONFTEST._suite_ops.clear()
+    CONFTEST._test_proto_refs.clear()
+    CONFTEST.pytest_collection_modifyitems(None, None, [item])
+
+    assert CONFTEST._test_proto_refs == {
+        "OnnxBackendNodeModelTest::test_add_cpu": proto_ref
+    }

--- a/test/test_conftest_ops.py
+++ b/test/test_conftest_ops.py
@@ -8,7 +8,9 @@ from pathlib import Path
 
 
 CONFTEST_PATH = Path(__file__).resolve().parent / "conftest.py"
-SPEC = importlib.util.spec_from_file_location("scoreboard_pytest_conftest", CONFTEST_PATH)
+SPEC = importlib.util.spec_from_file_location(
+    "scoreboard_pytest_conftest", CONFTEST_PATH
+)
 CONFTEST = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(CONFTEST)
 

--- a/test/test_merge_trends.py
+++ b/test/test_merge_trends.py
@@ -6,7 +6,12 @@ import json
 
 from pathlib import Path
 
-from scripts.merge_trends import build_summary, merge_trend
+from scripts.merge_trends import (
+    build_summary,
+    count_total_ops,
+    count_total_ops_from_ops_json,
+    merge_trend,
+)
 
 
 def test_build_summary_uses_report_and_core_packages(tmp_path):
@@ -23,10 +28,14 @@ def test_build_summary_uses_report_and_core_packages(tmp_path):
         {"name": "onnxruntime", "version": "1.22.0"},
         {"name": "numpy", "version": "2.0.0"},
     ]
-    nodes_csv = "Op,None\nAdd,Passed!\nMul,Failed!\nMul,Passed!\n"
+    ops = [
+        {"domain": "", "op_type": "Add"},
+        {"domain": "ai.onnx.ml", "op_type": "ArrayFeatureExtractor"},
+        {"domain": "", "op_type": "Add"},
+    ]
     (results_dir / "report.json").write_text(json.dumps(report))
     (results_dir / "pip-list.json").write_text(json.dumps(package_versions))
-    (results_dir / "nodes.csv").write_text(nodes_csv)
+    (results_dir / "ops.json").write_text(json.dumps(ops))
 
     summary = build_summary(results_dir, {"core_packages": ["onnxruntime"]})
 
@@ -41,6 +50,32 @@ def test_build_summary_uses_report_and_core_packages(tmp_path):
             {"name": "onnxruntime", "version": "1.22.0"},
         ],
     }
+
+
+def test_count_total_ops_prefers_ops_json(tmp_path):
+    """Use ops.json as the authoritative source when present."""
+    results_dir = Path(tmp_path)
+    ops = [
+        {"domain": "", "op_type": "Add"},
+        {"domain": "ai.onnx.ml", "op_type": "ArrayFeatureExtractor"},
+        {"domain": "", "op_type": "Add"},
+    ]
+    (results_dir / "ops.json").write_text(json.dumps(ops))
+    (results_dir / "nodes.csv").write_text("Op,None\nAdd,Passed!\nMul,Failed!\n")
+
+    assert count_total_ops_from_ops_json(results_dir) == 2
+    assert count_total_ops(results_dir) == 2
+
+
+def test_count_total_ops_falls_back_to_nodes_csv_without_ops_json(tmp_path):
+    """Keep supporting older artifacts that only have nodes.csv."""
+    results_dir = Path(tmp_path)
+    (results_dir / "nodes.csv").write_text(
+        "Op,None\nAdd,Passed!\nMul,Failed!\nSummary,1/2 node tests passed\n"
+    )
+
+    assert count_total_ops_from_ops_json(results_dir) == 0
+    assert count_total_ops(results_dir) == 2
 
 
 def test_merge_trend_appends_new_summary():


### PR DESCRIPTION
## Summary
- the generated nodes.csv has systematical errors
- introduce a new ops.json with more detailed operator coverage information that can be used in future
