### PR TITLE
Fix OpenVINO results mount/env path

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,6 @@
+# GitHub Copilot instructions
+
+Follow the repository rules in `/AGENTS.md`.
+
+In particular: every commit must be DCO signed (include a `Signed-off-by: Name <email>` line). Prefer `git commit -s`.
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,3 @@
 # GitHub Copilot instructions
 
 Follow the repository rules in `/AGENTS.md`.
-
-In particular: every commit must be DCO signed (include a `Signed-off-by: Name <email>` line). Prefer `git commit -s`.
-

--- a/.github/workflows/benchmark-backends.yml
+++ b/.github/workflows/benchmark-backends.yml
@@ -288,7 +288,12 @@ jobs:
         run: mkdir -p ${{ github.workspace }}/results/onnxruntime-openvino/stable && chmod 777 ${{ github.workspace }}/results/onnxruntime-openvino/stable
 
       - name: Run docker container
-        run: docker run --name onnxruntime-openvino --env-file setup/env.list -v ${{ github.workspace }}/results/onnxruntime-openvino/stable:/root/results scoreboard/onnxruntime-openvino || true
+        run: |
+          docker run --name onnxruntime-openvino --env-file setup/env.list \
+            -e RESULTS_DIR=/home/onnx/results \
+            -e CSVDIR=/home/onnx/results \
+            -v ${{ github.workspace }}/results/onnxruntime-openvino/stable:/home/onnx/results \
+            scoreboard/onnxruntime-openvino || true
 
       - name: Upload results
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent instructions
+
+- Every commit must be DCO signed (include a `Signed-off-by: Name <email>` line). Use `git commit -s`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,4 @@
 # Agent instructions
 
 - Every commit must be DCO signed (include a `Signed-off-by: Name <email>` line). Use `git commit -s`.
+- Before creating a PR, run Ruff the same way CI does: `ruff check test website-generator backends` and `ruff format --check test website-generator backends`.


### PR DESCRIPTION
The onnxruntime-openvino image runs as the non-root user onnx, but the workflow passed RESULTS_DIR=/root/results (via setup/env.list) and mounted the host results dir to /root/results. This caused a permission error when writing pip-list.json, so no artifact was uploaded and collect_and_deploy failed to download esults-onnxruntime-openvino-stable (run 23887743665).

This change mounts the results directory to /home/onnx/results and overrides RESULTS_DIR/CSVDIR for the OpenVINO job.