### PR TITLE
Replace onnxruntime-openvino with ABI EP plugin onnxruntime-ep-openvino

### DIFF
--- a/.github/workflows/benchmark-backends.yml
+++ b/.github/workflows/benchmark-backends.yml
@@ -288,7 +288,12 @@ jobs:
         run: mkdir -p ${{ github.workspace }}/results/onnxruntime-openvino/stable && chmod 777 ${{ github.workspace }}/results/onnxruntime-openvino/stable
 
       - name: Run docker container
-        run: docker run --name onnxruntime-openvino --env-file setup/env.list -v ${{ github.workspace }}/results/onnxruntime-openvino/stable:/root/results scoreboard/onnxruntime-openvino || true
+        run: |
+          docker run --name onnxruntime-openvino --env-file setup/env.list \
+            -e RESULTS_DIR=/home/onnx/results \
+            -e CSVDIR=/home/onnx/results \
+            -v ${{ github.workspace }}/results/onnxruntime-openvino/stable:/home/onnx/results \
+            scoreboard/onnxruntime-openvino || true
 
       - name: Upload results
         if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/backends/onnxruntime_openvino/backend.py
+++ b/backends/onnxruntime_openvino/backend.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""ONNX backend wrapper for ONNX Runtime with the OpenVINO Execution Provider.
+
+This wrapper uses subprocess isolation (same pattern as tract, opencv, and tvm
+backends): each inference call runs inside a short-lived
+``multiprocessing.Process`` so that a crash only affects a single test.
+"""
+
+import multiprocessing as mp
+import os
+import unittest
+
+import numpy as np
+from onnx.backend.base import Backend, BackendRep
+from onnx.backend.test.runner import BackendIsNotSupposedToImplementIt
+
+
+_TIMEOUT = int(os.getenv("OVEP_TEST_TIMEOUT", "120"))
+
+
+def _check_released_opsets(model):
+    """Skip test if the model uses an unreleased opset version."""
+    from onnx import helper
+
+    allow_released_only = os.getenv("ALLOW_RELEASED_ONNX_OPSET_ONLY", "1") == "1"
+    if allow_released_only:
+        for opset in model.opset_import:
+            domain = opset.domain if opset.domain else "ai.onnx"
+            key = (domain, opset.version)
+            if key not in helper.OP_SET_ID_VERSION_MAP:
+                raise unittest.SkipTest(
+                    f"Skipping: unreleased opset {domain} v{opset.version}"
+                )
+
+
+def _ort_openvino_worker(model_bytes, inputs, result_queue):
+    """Run ORT + OpenVINO EP inference in an isolated subprocess."""
+    try:
+        import onnxruntime as ort
+
+        providers = ort.get_available_providers()
+        sess = ort.InferenceSession(model_bytes, providers=providers)
+        sess.disable_fallback()
+
+        input_names = [inp.name for inp in sess.get_inputs()]
+        feed = {}
+        if isinstance(inputs, list):
+            for name, data in zip(input_names, inputs, strict=False):
+                feed[name] = np.asarray(data)
+        else:
+            if len(input_names) != 1:
+                result_queue.put(("error", f"Model expects {len(input_names)} inputs"))
+                return
+            feed[input_names[0]] = np.asarray(inputs)
+
+        outputs = sess.run(None, feed)
+        result_queue.put(("ok", outputs))
+    except (RuntimeError, ValueError, OSError) as e:
+        result_queue.put(("error", f"{type(e).__name__}: {e}"))
+
+
+class OrtOpenVinoBackendRep(BackendRep):
+    """Runtime representation that runs each inference in a subprocess."""
+
+    def __init__(self, model_bytes):
+        """Store serialized model bytes for subprocess execution."""
+        self.model_bytes = model_bytes
+
+    def run(self, inputs, **kwargs):
+        """Execute inference in a spawned worker process."""
+        ctx = mp.get_context("spawn")
+        q = ctx.Queue()
+        p = ctx.Process(
+            target=_ort_openvino_worker,
+            args=(self.model_bytes, inputs, q),
+        )
+        p.start()
+        p.join(timeout=_TIMEOUT)
+        if p.is_alive():
+            p.terminate()
+            p.join()
+            raise BackendIsNotSupposedToImplementIt(
+                "onnxruntime-openvino process timed out"
+            )
+        if p.exitcode != 0:
+            raise BackendIsNotSupposedToImplementIt(
+                f"onnxruntime-openvino process crashed (exit code {p.exitcode})"
+            )
+        if q.empty():
+            raise BackendIsNotSupposedToImplementIt(
+                "onnxruntime-openvino worker produced no output"
+            )
+        status, result = q.get_nowait()
+        if status == "error":
+            raise BackendIsNotSupposedToImplementIt(result)
+        return result
+
+
+class OrtOpenVinoBackend(Backend):
+    """ONNX backend backed by ONNX Runtime with the OpenVINO EP."""
+
+    @classmethod
+    def is_compatible(cls, model, device="CPU", **kwargs):
+        """Return whether the model is compatible with this backend."""
+        return cls.supports_device(device)
+
+    @classmethod
+    def prepare(cls, model, device="CPU", **kwargs):
+        """Serialize the model and return a runnable backend representation."""
+        if isinstance(model, (str, bytes)):
+            if isinstance(model, bytes):
+                model_bytes = model
+            else:
+                with open(model, "rb") as f:
+                    model_bytes = f.read()
+        else:
+            # ModelProto
+            from onnx.checker import check_model
+
+            try:
+                model_bytes = model.SerializeToString()
+                check_model(model_bytes)
+            except (ValueError, RuntimeError, OSError) as e:
+                raise unittest.SkipTest(f"Model validation failed: {e}") from e
+
+            _check_released_opsets(model)
+
+        return OrtOpenVinoBackendRep(model_bytes)
+
+    @classmethod
+    def run_model(cls, model, inputs, device="CPU", **kwargs):
+        """Prepare then run a model in one call."""
+        return cls.prepare(model, device, **kwargs).run(inputs)
+
+    @classmethod
+    def supports_device(cls, device):
+        """Return whether the backend supports the given device."""
+        return device == "CPU"
+
+
+prepare = OrtOpenVinoBackend.prepare
+run_model = OrtOpenVinoBackend.run_model
+supports_device = OrtOpenVinoBackend.supports_device

--- a/runtimes/onnxruntime-openvino/development/Dockerfile
+++ b/runtimes/onnxruntime-openvino/development/Dockerfile
@@ -1,19 +1,5 @@
 FROM ubuntu:22.04
 
-# Proxy build arguments (passed via --build-arg)
-ARG http_proxy
-ARG https_proxy
-ARG ftp_proxy
-ARG socks_proxy
-ARG no_proxy
-
-# Expose proxy settings to all subsequent RUN steps
-ENV http_proxy=${http_proxy}
-ENV https_proxy=${https_proxy}
-ENV ftp_proxy=${ftp_proxy}
-ENV socks_proxy=${socks_proxy}
-ENV no_proxy=${no_proxy}
-
 # Disable interactive installation mode
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -24,52 +10,40 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     locales \
     dos2unix && \
-    apt-get clean autoclean && apt-get autoremove -y
+    apt-get clean autoclean && apt-get autoremove -y && \
+    pip3 install --upgrade pip setuptools wheel
 
-RUN pip3 install --upgrade pip setuptools wheel
-
-# Create a non-root user for running the container
-RUN useradd -m -s /bin/bash onnx
+# Create working directory
+RUN useradd -m onnx
+WORKDIR /home/onnx
 
 # Copy local directories
 COPY ./test /home/onnx/test
 COPY ./setup /home/onnx/setup
+COPY ./backends/onnxruntime_openvino/backend.py /home/onnx/onnxruntime_openvino_backend.py
 
-# Fix Windows line endings on all shell scripts and Python files
-RUN find /home/onnx/setup /home/onnx/test -type f \( -name "*.sh" -o -name "*.py" -o -name "*.txt" -o -name "*.json" \) -exec dos2unix {} +
+# Fix Windows line endings
+RUN find /home/onnx/setup /home/onnx/test -type f \( -name "*.sh" -o -name "*.py" -o -name "*.txt" -o -name "*.json" \) -exec dos2unix {} + && \
+    dos2unix /home/onnx/onnxruntime_openvino_backend.py
 
 # Install test report dependencies
-RUN pip3 install --no-cache-dir -r /home/onnx/setup/requirements_report.txt
+RUN pip3 install --no-cache-dir -r /home/onnx/setup/requirements_report.txt && \
+    mkdir -p /home/onnx/results
 
 ############## ONNX Backend dependencies ###########
-# onnxruntime-openvino bundles ORT with the OpenVINO Execution Provider
-# and exposes the same onnxruntime.backend.backend interface
-ENV ONNX_BACKEND="onnxruntime.backend.backend"
+ENV ONNX_BACKEND="onnxruntime_openvino_backend"
+ENV PYTHONPATH="/home/onnx"
+ENV RESULTS_DIR="/home/onnx/results"
+ENV CSVDIR="/home/onnx/results"
 
-# Set locale which is required for StringNormalizer
-RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
-
-# Install development/nightly onnxruntime-openvino (includes ORT + OpenVINO EP)
-# pytest-forked isolates each test in a subprocess so that segfaults
-# in the OpenVINO EP crash only that test, not the whole run.
-# --pre allows installing pre-release/dev versions from PyPI.
-RUN pip3 install --no-cache-dir --pre \
+# Set locale and install ONNX Runtime with OpenVINO ABI EP plugin (pre-release)
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8 && \
+    pip3 install --no-cache-dir --pre \
     onnx \
-    onnxruntime-openvino \
+    onnxruntime \
+    onnxruntime-ep-openvino \
     protobuf \
-    numpy \
-    pytest-forked
+    numpy
 ####################################################
 
-# Ensure results directory exists so docker-setup.sh can write pip-list.json
-RUN mkdir -p /home/onnx/results
-
-# Override default paths (env.list uses /root) for the non-root user
-ENV RESULTS_DIR=/home/onnx/results
-ENV CSVDIR=/home/onnx/results
-
-# Set ownership and switch to non-root user
-RUN chown -R onnx:onnx /home/onnx
-USER onnx
-
-CMD ["sh", "-c", ". /home/onnx/setup/docker-setup.sh && pytest /home/onnx/test/test_backend.py --onnx_backend=${ONNX_BACKEND} -k 'not _cuda' --forked -v"]
+CMD ["sh", "-c", ". /home/onnx/setup/docker-setup.sh && pytest /home/onnx/test/test_backend.py --onnx_backend=${ONNX_BACKEND} -k 'not _cuda' -v"]

--- a/runtimes/onnxruntime-openvino/stable/Dockerfile
+++ b/runtimes/onnxruntime-openvino/stable/Dockerfile
@@ -1,19 +1,5 @@
 FROM ubuntu:22.04
 
-# Proxy build arguments (passed via --build-arg)
-ARG http_proxy
-ARG https_proxy
-ARG ftp_proxy
-ARG socks_proxy
-ARG no_proxy
-
-# Expose proxy settings to all subsequent RUN steps
-ENV http_proxy=${http_proxy}
-ENV https_proxy=${https_proxy}
-ENV ftp_proxy=${ftp_proxy}
-ENV socks_proxy=${socks_proxy}
-ENV no_proxy=${no_proxy}
-
 # Disable interactive installation mode
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -24,51 +10,40 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     locales \
     dos2unix && \
-    apt-get clean autoclean && apt-get autoremove -y
+    apt-get clean autoclean && apt-get autoremove -y && \
+    pip3 install --upgrade pip setuptools wheel
 
-RUN pip3 install --upgrade pip setuptools wheel
-
-# Create a non-root user for running the container
-RUN useradd -m -s /bin/bash onnx
+# Create working directory
+RUN useradd -m onnx
+WORKDIR /home/onnx
 
 # Copy local directories
 COPY ./test /home/onnx/test
 COPY ./setup /home/onnx/setup
+COPY ./backends/onnxruntime_openvino/backend.py /home/onnx/onnxruntime_openvino_backend.py
 
-# Fix Windows line endings on all shell scripts and Python files
-RUN find /home/onnx/setup /home/onnx/test -type f \( -name "*.sh" -o -name "*.py" -o -name "*.txt" -o -name "*.json" \) -exec dos2unix {} +
+# Fix Windows line endings
+RUN find /home/onnx/setup /home/onnx/test -type f \( -name "*.sh" -o -name "*.py" -o -name "*.txt" -o -name "*.json" \) -exec dos2unix {} + && \
+    dos2unix /home/onnx/onnxruntime_openvino_backend.py
 
 # Install test report dependencies
-RUN pip3 install --no-cache-dir -r /home/onnx/setup/requirements_report.txt
+RUN pip3 install --no-cache-dir -r /home/onnx/setup/requirements_report.txt && \
+    mkdir -p /home/onnx/results
 
 ############## ONNX Backend dependencies ###########
-# onnxruntime-openvino bundles ORT with the OpenVINO Execution Provider
-# and exposes the same onnxruntime.backend.backend interface
-ENV ONNX_BACKEND="onnxruntime.backend.backend"
+ENV ONNX_BACKEND="onnxruntime_openvino_backend"
+ENV PYTHONPATH="/home/onnx"
+ENV RESULTS_DIR="/home/onnx/results"
+ENV CSVDIR="/home/onnx/results"
 
-# Set locale which is required for StringNormalizer
-RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8
-
-# Install onnxruntime-openvino (includes ORT + OpenVINO EP)
-# pytest-forked isolates each test in a subprocess so that segfaults
-# in the OpenVINO EP crash only that test, not the whole run.
-RUN pip3 install --no-cache-dir \
+# Set locale and install ONNX Runtime with OpenVINO ABI EP plugin
+RUN locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8 && \
+    pip3 install --no-cache-dir \
     onnx \
-    onnxruntime-openvino \
+    onnxruntime \
+    onnxruntime-ep-openvino \
     protobuf \
-    numpy \
-    pytest-forked
+    numpy
 ####################################################
 
-# Ensure results directory exists so docker-setup.sh can write pip-list.json
-RUN mkdir -p /home/onnx/results
-
-# Override default paths (env.list uses /root) for the non-root user
-ENV RESULTS_DIR=/home/onnx/results
-ENV CSVDIR=/home/onnx/results
-
-# Set ownership and switch to non-root user
-RUN chown -R onnx:onnx /home/onnx
-USER onnx
-
-CMD ["sh", "-c", ". /home/onnx/setup/docker-setup.sh && pytest /home/onnx/test/test_backend.py --onnx_backend=${ONNX_BACKEND} -k 'not _cuda' --forked -v"]
+CMD ["sh", "-c", ". /home/onnx/setup/docker-setup.sh && pytest /home/onnx/test/test_backend.py --onnx_backend=${ONNX_BACKEND} -k 'not _cuda' -v"]

--- a/setup/config.json
+++ b/setup/config.json
@@ -76,9 +76,9 @@
             "name": "ONNX-Runtime OpenVINO EP",
             "link": "https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html",
             "description": "ONNX Runtime with the OpenVINO Execution Provider for accelerated inference on Intel hardware.",
-            "long_description": "ONNX Runtime OpenVINO Execution Provider integrates Intel's OpenVINO toolkit into ORT to accelerate inference on Intel CPUs, integrated GPUs, and VPUs. The onnxruntime-openvino PyPI package bundles ORT with the OpenVINO EP and exposes the standard onnxruntime.backend.backend interface, making it a drop-in replacement for plain onnxruntime while enabling hardware-optimized execution paths for supported Intel targets.",
+            "long_description": "ONNX Runtime OpenVINO Execution Provider integrates Intel's OpenVINO toolkit into ORT to accelerate inference on Intel CPUs, integrated GPUs, and VPUs. The onnxruntime-ep-openvino ABI EP plugin loads OpenVINO as a shared library at runtime alongside onnxruntime, enabling hardware-optimized execution paths for supported Intel targets.",
             "results_dir": "./results/onnxruntime-openvino/stable",
-            "core_packages": ["onnxruntime-openvino"],
+            "core_packages": ["onnxruntime", "onnxruntime-ep-openvino"],
             "dockerfile_link": "runtimes/onnxruntime-openvino/stable/Dockerfile"
         }
     },


### PR DESCRIPTION
This PR updates the ONNX Runtime OpenVINO EP integration to use the newer onnxruntime-ep-openvino plugin package, replacing the legacy onnxruntime-openvino bundle. It also introduces a custom backend wrapper with built-in process isolation, removing the dependency on pytest-forked.

**Changes**

- New backend wrapper (backend.py): Custom ONNX backend with subprocess isolation per inference call — crashes in one test don't take down the suite.
- Dockerfiles simplified (stable + development): Removed hardcoded proxy args, consolidated RUN layers, switched to onnxruntime + onnxruntime-ep-openvino, dropped pytest-forked.
- CI workflow updated: Corrected volume mount paths and environment variables for result collection.
- config.json updated: Reflects the new package names and description.