### PR TITLE
Fix jaxonnxruntime_dev CI: upgrade Python 3.9 -> 3.10

### DIFF
--- a/runtimes/jaxonnxruntime/development/Dockerfile
+++ b/runtimes/jaxonnxruntime/development/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 # Disable interactive installation mode
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Root cause

PR #117 bumped `pytest` to `>=9.0.3` in `requirements_report.txt`, but `pytest>=9.0` requires Python >=3.10. The `jaxonnxruntime/development/Dockerfile` was still on `python:3.9`, so the Docker build step failed with:

```
ERROR: Ignored the following versions that require a different python version: 9.0.0 Requires-Python >=3.10 ...
ERROR: No matching distribution found for pytest>=9.0.3
```

## Fix

Bump base image from `python:3.9` to `python:3.10`, matching the existing `stable/Dockerfile`.

## Verification

This is a one-line change identical to what `stable/Dockerfile` already uses.