### PR TITLE
Fix onnx-tf CI: pin pytest<9 for Python 3.8 compatibility

### DIFF
--- a/runtimes/onnx-tf/development/Dockerfile
+++ b/runtimes/onnx-tf/development/Dockerfile
@@ -16,8 +16,11 @@ RUN apt-get update && apt-get install -y \
 COPY ./test /root/test
 COPY ./setup /root/setup
 
-# Install test report dependencies
-RUN pip3 install --no-cache-dir -r /root/setup/requirements_report.txt
+# Install test report dependencies (pytest<9 required for Python 3.8)
+RUN pip3 install --no-cache-dir \
+    "pytest>=8.0,<9" \
+    "tabulate>=0.10.0" \
+    "PyYAML>=6.0.3"
 
 ############## ONNX Backend dependencies ###########
 ENV ONNX_BACKEND="onnx_tf.backend"

--- a/runtimes/onnx-tf/stable/Dockerfile
+++ b/runtimes/onnx-tf/stable/Dockerfile
@@ -15,8 +15,11 @@ RUN apt-get update && apt-get install -y \
 COPY ./test /root/test
 COPY ./setup /root/setup
 
-# Install test report dependencies
-RUN pip3 install --no-cache-dir -r /root/setup/requirements_report.txt
+# Install test report dependencies (pytest<9 required for Python 3.8)
+RUN pip3 install --no-cache-dir \
+    "pytest>=8.0,<9" \
+    "tabulate>=0.10.0" \
+    "PyYAML>=6.0.3"
 
 ############## ONNX Backend dependencies ###########
 ENV ONNX_BACKEND="onnx_tf.backend"


### PR DESCRIPTION
## Problem

The onnx-tf stable and development Dockerfiles use `ubuntu:20.04`, which ships with Python 3.8. Since PR #117 bumped the shared `requirements_report.txt` to `pytest>=9.0.3`, both jobs have been failing at Docker build time — pytest 9.x dropped Python 3.8 support and is simply not available for it.

```
ERROR: Could not find a version that satisfies the requirement pytest>=9.0.3
ERROR: No matching distribution found for pytest>=9.0.3
```

## Fix

Instead of using the shared `requirements_report.txt` in the onnx-tf Dockerfiles, install the three dependencies inline with `pytest` pinned to `>=8.0,<9` (latest: 8.3.5). This keeps the shared requirements file unchanged so all other runtimes (Ubuntu 22.04/24.04, Python 3.10+) are unaffected.

## Test plan

- [ ] Verify `onnx_tf_stable` and `onnx_tf_dev` Docker build steps pass in CI
- [ ] Confirm other runtime jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)