### PR TITLE
Add scoreboard freshness check that opens an issue on stale data

### DIFF
--- a/.github/workflows/scoreboard-freshness.yml
+++ b/.github/workflows/scoreboard-freshness.yml
@@ -20,12 +20,12 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
@@ -37,7 +37,7 @@ jobs:
             --max-age-days 3
 
       - name: Open, update or close the tracking issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           STALE: ${{ steps.check.outputs.stale }}
           STALE_BACKENDS: ${{ steps.check.outputs.stale_backends }}

--- a/.github/workflows/scoreboard-freshness.yml
+++ b/.github/workflows/scoreboard-freshness.yml
@@ -1,0 +1,99 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Scoreboard freshness check
+
+on:
+  schedule:
+    # Run a few hours after the website is rebuilt/deployed.
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check_freshness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Check published scoreboard freshness
+        id: check
+        run: |
+          python3 scripts/check_scoreboard_freshness.py \
+            --url "https://onnx.ai/backend-scoreboard/index.html" \
+            --max-age-days 3
+
+      - name: Open, update or close the tracking issue
+        uses: actions/github-script@v7
+        env:
+          STALE: ${{ steps.check.outputs.stale }}
+          STALE_BACKENDS: ${{ steps.check.outputs.stale_backends }}
+          ISSUE_BODY: ${{ steps.check.outputs.body }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const label = 'scoreboard-stale';
+            const title = '⚠️ Scoreboard data is out of date';
+            const stale = process.env.STALE === 'true';
+            const footer = `\n\n---\n_Automated by [Scoreboard freshness check](${process.env.RUN_URL})._`;
+            const body = (process.env.ISSUE_BODY || '').trim() + footer;
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+            const issue = existing.find(i => i.title === title) || existing[0];
+
+            if (stale) {
+              if (issue) {
+                // Refresh the body silently so we don't spam subscribers daily.
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body,
+                });
+                core.info(`Updated existing issue #${issue.number}`);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title,
+                  body,
+                  labels: [label],
+                });
+                core.info(`Created issue #${created.data.number}`);
+              }
+            } else if (issue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `✅ All scoreboard backends are up to date again as of this run.${footer}`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+              core.info(`Closed resolved issue #${issue.number}`);
+            } else {
+              core.info('Scoreboard is fresh; nothing to do.');
+            }

--- a/.github/workflows/scoreboard-freshness.yml
+++ b/.github/workflows/scoreboard-freshness.yml
@@ -51,6 +51,25 @@ jobs:
             const footer = `\n\n---\n_Automated by [Scoreboard freshness check](${process.env.RUN_URL})._`;
             const body = (process.env.ISSUE_BODY || '').trim() + footer;
 
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'd73a4a',
+                description: 'Tracking issue for stale backend scoreboard data',
+              });
+            }
+
             const existing = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -58,7 +77,7 @@ jobs:
               labels: label,
               per_page: 100,
             });
-            const issue = existing.find(i => i.title === title) || existing[0];
+            const issue = existing.find(i => i.title === title);
 
             if (stale) {
               if (issue) {

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Developer scripts for test only
 scripts/*
 !scripts/merge_trends.py
+!scripts/check_scoreboard_freshness.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/scripts/check_scoreboard_freshness.py
+++ b/scripts/check_scoreboard_freshness.py
@@ -1,0 +1,210 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Check whether the published scoreboard page shows up-to-date data.
+
+The script downloads the rendered scoreboard page (by default the public
+``index.html``), reads the per-backend "Date" values that the website renders
+from ``trend[-1].date`` and reports any backend whose latest update is older
+than a configurable threshold (default: 3 days).
+
+It is meant to run in CI: results are written to ``GITHUB_OUTPUT`` so a
+follow-up step can open / update / close a single tracking issue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+
+from datetime import datetime, timezone
+
+
+DEFAULT_URL = "https://onnx.ai/backend-scoreboard/index.html"
+
+# The website embeds the full scoreboard as JSON in
+# <div id="content" database='{...}'>. The visible "Date" column is rendered
+# from each backend's last trend entry (trend[-1].date).
+DATABASE_RE = re.compile(r"database='(.*?)'>", re.DOTALL)
+
+# Date format produced by website-generator/generator.py:
+# datetime.now().strftime("%m/%d/%Y %H:%M:%S")
+DATE_FORMAT = "%m/%d/%Y %H:%M:%S"
+
+
+def fetch_html(url: str, timeout: int = 60) -> str:
+    """Download the scoreboard page."""
+    headers = {"User-Agent": "scoreboard-freshness-check"}
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.read().decode(charset, errors="replace")
+
+
+def extract_database(html: str) -> dict:
+    """Extract and parse the embedded scoreboard database JSON."""
+    match = DATABASE_RE.search(html)
+    if not match:
+        raise ValueError("Could not find the 'database' payload in the page")
+    return json.loads(match.group(1))
+
+
+def latest_date(backend_data: dict) -> str | None:
+    """Return the most recent trend date string for a backend, if any."""
+    trend = backend_data.get("trend") or []
+    if not trend:
+        return None
+    return trend[-1].get("date")
+
+
+def parse_date(value: str) -> datetime:
+    """Parse a scoreboard date string as a UTC datetime."""
+    return datetime.strptime(value, DATE_FORMAT).replace(tzinfo=timezone.utc)
+
+
+def evaluate(database: dict, max_age_days: float, now: datetime) -> list[dict]:
+    """Return a per-backend freshness report sorted by descending age."""
+    report = []
+    for backend, backend_data in database.items():
+        name = backend_data.get("name", backend)
+        date_str = latest_date(backend_data)
+
+        if not date_str:
+            report.append(
+                {
+                    "backend": backend,
+                    "name": name,
+                    "date": None,
+                    "age_days": None,
+                    "stale": True,
+                    "reason": "no trend data",
+                }
+            )
+            continue
+
+        try:
+            updated = parse_date(date_str)
+        except ValueError:
+            report.append(
+                {
+                    "backend": backend,
+                    "name": name,
+                    "date": date_str,
+                    "age_days": None,
+                    "stale": True,
+                    "reason": "unparseable date",
+                }
+            )
+            continue
+
+        age_days = (now - updated).total_seconds() / 86400.0
+        report.append(
+            {
+                "backend": backend,
+                "name": name,
+                "date": date_str,
+                "age_days": age_days,
+                "stale": age_days > max_age_days,
+                "reason": "",
+            }
+        )
+
+    def sort_key(row: dict) -> float:
+        return -1.0 if row["age_days"] is None else row["age_days"]
+
+    report.sort(key=sort_key, reverse=True)
+    return report
+
+
+def render_markdown(
+    report: list[dict], url: str, max_age_days: float, now: datetime
+) -> str:
+    """Build a Markdown summary suitable for an issue body."""
+    stale = [row for row in report if row["stale"]]
+    lines = [
+        f"The scoreboard page reports data older than **{max_age_days:g} days** "
+        f"for {len(stale)} of {len(report)} backend(s).",
+        "",
+        f"- Source: {url}",
+        f"- Checked at: {now.strftime('%Y-%m-%d %H:%M:%S')} UTC",
+        "",
+        "| Backend | Last update (UTC) | Age | Status |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in report:
+        if row["age_days"] is None:
+            age = row["reason"] or "unknown"
+        else:
+            age = f"{row['age_days']:.1f} days"
+        status = "⚠️ stale" if row["stale"] else "✅ ok"
+        lines.append(f"| {row['name']} | {row['date'] or '—'} | {age} | {status} |")
+    return "\n".join(lines)
+
+
+def write_outputs(stale: bool, report: list[dict], body: str) -> None:
+    """Expose results to later workflow steps via GITHUB_OUTPUT."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    stale_names = ", ".join(row["name"] for row in report if row["stale"])
+    with open(output_path, "a", encoding="utf-8") as handle:
+        handle.write(f"stale={'true' if stale else 'false'}\n")
+        handle.write(f"stale_count={sum(1 for row in report if row['stale'])}\n")
+        handle.write(f"stale_backends={stale_names}\n")
+        handle.write("body<<FRESHNESS_EOF\n")
+        handle.write(body + "\n")
+        handle.write("FRESHNESS_EOF\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the freshness check and emit a report plus CI outputs."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=DEFAULT_URL, help="Scoreboard page URL")
+    parser.add_argument(
+        "--html-file",
+        help="Read the page from a local file instead of fetching it (for testing)",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=float,
+        default=3.0,
+        help="A backend is stale if its latest date is older than this many days "
+        "(default: 3)",
+    )
+    args = parser.parse_args(argv)
+
+    source = args.html_file or args.url
+    try:
+        if args.html_file:
+            with open(args.html_file, encoding="utf-8") as handle:
+                html = handle.read()
+        else:
+            html = fetch_html(args.url)
+        database = extract_database(html)
+    except Exception as error:  # noqa: BLE001 - surface any failure as a stale signal
+        message = f"Failed to read scoreboard data from {source}: {error}"
+        print(message, file=sys.stderr)
+        body = (
+            f"The freshness check could not read the scoreboard page.\n\n"
+            f"- Source: {source}\n- Error: `{error}`"
+        )
+        write_outputs(True, [], body)
+        return 0
+
+    now = datetime.now(timezone.utc)
+    report = evaluate(database, args.max_age_days, now)
+    stale = any(row["stale"] for row in report)
+    body = render_markdown(report, source, args.max_age_days, now)
+
+    print(body)
+    write_outputs(stale, report, body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_scoreboard_freshness.py
+++ b/scripts/check_scoreboard_freshness.py
@@ -23,6 +23,8 @@ import sys
 import urllib.request
 
 from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
 
 
 DEFAULT_URL = "https://onnx.ai/backend-scoreboard/index.html"
@@ -39,11 +41,24 @@ DATE_FORMAT = "%m/%d/%Y %H:%M:%S"
 
 def fetch_html(url: str, timeout: int = 60) -> str:
     """Download the scoreboard page."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"Unsupported scoreboard URL: {url!r}")
+    if parsed.username or parsed.password:
+        raise ValueError("Scoreboard URL must not include credentials")
     headers = {"User-Agent": "scoreboard-freshness-check"}
     request = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
         charset = response.headers.get_content_charset() or "utf-8"
         return response.read().decode(charset, errors="replace")
+
+
+def load_html_file(path: str) -> str:
+    """Read and return a validated local HTML file."""
+    html_path = Path(path).expanduser().resolve(strict=True)
+    if not html_path.is_file():
+        raise ValueError(f"Scoreboard HTML path must point to a file: {path!r}")
+    return html_path.read_text(encoding="utf-8")
 
 
 def extract_database(html: str) -> dict:
@@ -181,8 +196,7 @@ def main(argv: list[str] | None = None) -> int:
     source = args.html_file or args.url
     try:
         if args.html_file:
-            with open(args.html_file, encoding="utf-8") as handle:
-                html = handle.read()
+            html = load_html_file(args.html_file)
         else:
             html = fetch_html(args.url)
         database = extract_database(html)
@@ -194,7 +208,7 @@ def main(argv: list[str] | None = None) -> int:
             f"- Source: {source}\n- Error: `{error}`"
         )
         write_outputs(True, [], body)
-        return 0
+        return 1
 
     now = datetime.now(timezone.utc)
     report = evaluate(database, args.max_age_days, now)

--- a/test/test_scoreboard_freshness.py
+++ b/test/test_scoreboard_freshness.py
@@ -70,6 +70,7 @@ def test_evaluate_marks_stale_and_missing_backends():
 def test_render_markdown_includes_backend_statuses():
     """Render a stable issue body that highlights stale backends."""
     now = datetime(2026, 3, 28, 0, 50, 48, tzinfo=timezone.utc)
+    source = "scoreboard-source"
     report = [
         {
             "backend": "stale",
@@ -89,12 +90,12 @@ def test_render_markdown_includes_backend_statuses():
         },
     ]
 
-    body = render_markdown(report, "https://example.invalid", 3.0, now)
+    body = render_markdown(report, source, 3.0, now)
 
     assert "Stale Backend" in body
     assert "✅ ok" in body
     assert "⚠️ stale" in body
-    assert "https://example.invalid" in body
+    assert source in body
 
 
 def test_parse_date_uses_scoreboard_format():

--- a/test/test_scoreboard_freshness.py
+++ b/test/test_scoreboard_freshness.py
@@ -1,0 +1,105 @@
+# Copyright (c) ONNX Project Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the scoreboard freshness checker script."""
+
+from __future__ import annotations
+
+import json
+
+from datetime import datetime, timezone
+
+from scripts.check_scoreboard_freshness import (
+    DATE_FORMAT,
+    evaluate,
+    extract_database,
+    latest_date,
+    parse_date,
+    render_markdown,
+)
+
+
+def test_extract_database_parses_embedded_payload():
+    """Read the embedded database JSON from the generated page."""
+    payload = json.dumps({"backend": {"name": "RTen"}})
+    html = "<div id='content' database='" + payload + "'>"
+    assert extract_database(html) == {"backend": {"name": "RTen"}}
+
+
+def test_latest_date_returns_last_trend_entry():
+    """Use the latest trend item when deriving freshness."""
+    backend_data = {
+        "trend": [
+            {"date": "03/24/2026 00:50:48"},
+            {"date": "03/25/2026 00:50:48"},
+        ]
+    }
+
+    assert latest_date(backend_data) == "03/25/2026 00:50:48"
+
+
+def test_evaluate_marks_stale_and_missing_backends():
+    """Classify stale, fresh, and missing-trend backends consistently."""
+    now = datetime(2026, 3, 28, 0, 50, 48, tzinfo=timezone.utc)
+    database = {
+        "fresh": {
+            "name": "Fresh Backend",
+            "trend": [{"date": "03/27/2026 00:50:48"}],
+        },
+        "stale": {
+            "name": "Stale Backend",
+            "trend": [{"date": "03/20/2026 00:50:48"}],
+        },
+        "missing": {"name": "Missing Backend", "trend": []},
+    }
+
+    report = evaluate(database, max_age_days=3.0, now=now)
+
+    assert {row["backend"] for row in report} == {"missing", "stale", "fresh"}
+    missing = next(row for row in report if row["backend"] == "missing")
+    stale = next(row for row in report if row["backend"] == "stale")
+    fresh = next(row for row in report if row["backend"] == "fresh")
+
+    assert missing["stale"] is True
+    assert missing["reason"] == "no trend data"
+    assert stale["stale"] is True
+    assert fresh["stale"] is False
+
+
+def test_render_markdown_includes_backend_statuses():
+    """Render a stable issue body that highlights stale backends."""
+    now = datetime(2026, 3, 28, 0, 50, 48, tzinfo=timezone.utc)
+    report = [
+        {
+            "backend": "stale",
+            "name": "Stale Backend",
+            "date": "03/20/2026 00:50:48",
+            "age_days": 8.0,
+            "stale": True,
+            "reason": "",
+        },
+        {
+            "backend": "fresh",
+            "name": "Fresh Backend",
+            "date": "03/27/2026 00:50:48",
+            "age_days": 1.0,
+            "stale": False,
+            "reason": "",
+        },
+    ]
+
+    body = render_markdown(report, "https://example.invalid", 3.0, now)
+
+    assert "Stale Backend" in body
+    assert "✅ ok" in body
+    assert "⚠️ stale" in body
+    assert "https://example.invalid" in body
+
+
+def test_parse_date_uses_scoreboard_format():
+    """Parse the website's date format into a UTC datetime."""
+    parsed = parse_date("03/25/2026 00:50:48")
+
+    assert parsed.tzinfo == timezone.utc
+    assert parsed.strftime(DATE_FORMAT) == "03/25/2026 00:50:48"


### PR DESCRIPTION
## Summary
- add standalone monitoring that checks the published backend scoreboard for freshness
- create or refresh a single tracking issue when the published data becomes stale
- add tests for the freshness checker parsing, classification, and rendering paths

## Updates Since Review
- create the `scoreboard-stale` label automatically if it is missing
- only act on the exact tracking-issue title instead of falling back to the first labeled issue
- add unit coverage for the freshness checker to protect the parsing and classification paths

## Validation
- `uv run --with ruff python -m ruff check scripts/check_scoreboard_freshness.py test/test_scoreboard_freshness.py`
- `uv run --with pytest python -m pytest test/test_scoreboard_freshness.py -v --onnx_backend=backends.rten.backend`