### PR TITLE
Fix scoreboard CI: onnx-tf Python 3.8 build + resilient deploy

### DIFF
--- a/.github/workflows/benchmark-backends.yml
+++ b/.github/workflows/benchmark-backends.yml
@@ -307,7 +307,9 @@ jobs:
     permissions:
       contents: write
     needs: [onnxruntime_stable, onnxruntime_dev, onnx_tf_stable, onnx_tf_dev, jaxonnxruntime_stable, jaxonnxruntime_dev, emx_onnx_cgen_stable, tract_stable, onnx_reference_stable, opencv_stable, tvm_stable, onnxruntime_openvino_stable]
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    # Run even if some backend jobs failed, so the scoreboard is still deployed
+    # with the results that did succeed (missing artifacts are skipped below).
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -337,72 +339,84 @@ jobs:
 
       - name: Download ort stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-ort-stable
           path: results/ort/stable/
 
       - name: Download onnx-tf stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-onnxtf-stable
           path: results/onnx-tf/stable/
 
       - name: Download onnx-tf dev results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-onnxtf-dev
           path: results/onnx-tf/development/
 
       - name: Download jaxonnxruntime stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-jaxonnxruntime-stable
           path: results/jaxonnxruntime/stable/
 
       - name: Download jaxonnxruntime dev results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-jaxonnxruntime-dev
           path: results/jaxonnxruntime/development/
 
       - name: Download ort dev results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-ort-dev
           path: results/ort/development/
 
       - name: Download emx-onnx-cgen stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-emx-onnx-cgen-stable
           path: results/emx-onnx-cgen/stable/
 
       - name: Download tract stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-tract-stable
           path: results/tract/stable/
 
       - name: Download ONNX reference stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-onnx-reference-stable
           path: results/onnx-reference/stable/
 
       - name: Download opencv stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-opencv-stable
           path: results/opencv/stable/
 
       - name: Download tvm stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-tvm-stable
           path: results/tvm/stable/
 
       - name: Download onnxruntime-openvino stable results
         uses: actions/download-artifact@v8
+        continue-on-error: true
         with:
           name: results-onnxruntime-openvino-stable
           path: results/onnxruntime-openvino/stable/

--- a/runtimes/onnx-tf/development/Dockerfile
+++ b/runtimes/onnx-tf/development/Dockerfile
@@ -16,10 +16,10 @@ RUN apt-get update && apt-get install -y \
 COPY ./test /root/test
 COPY ./setup /root/setup
 
-# Install test report dependencies (pytest<9 required for Python 3.8)
+# Install test report dependencies (pytest<9 and tabulate<0.10 required for Python 3.8)
 RUN pip3 install --no-cache-dir \
     "pytest>=8.0,<9" \
-    "tabulate>=0.10.0" \
+    "tabulate>=0.8.10,<0.10" \
     "PyYAML>=6.0.3"
 
 ############## ONNX Backend dependencies ###########

--- a/runtimes/onnx-tf/stable/Dockerfile
+++ b/runtimes/onnx-tf/stable/Dockerfile
@@ -15,10 +15,10 @@ RUN apt-get update && apt-get install -y \
 COPY ./test /root/test
 COPY ./setup /root/setup
 
-# Install test report dependencies (pytest<9 required for Python 3.8)
+# Install test report dependencies (pytest<9 and tabulate<0.10 required for Python 3.8)
 RUN pip3 install --no-cache-dir \
     "pytest>=8.0,<9" \
-    "tabulate>=0.10.0" \
+    "tabulate>=0.8.10,<0.10" \
     "PyYAML>=6.0.3"
 
 ############## ONNX Backend dependencies ###########


### PR DESCRIPTION
Restores the nightly **Run benchmarks** scoreboard, which had been failing every night.

## 1. Fix onnx-tf build (Python 3.8)

Both `onnx_tf_stable` and `onnx_tf_dev` failed at **Build docker image**:

```
ERROR: Could not find a version that satisfies the requirement tabulate>=0.10.0
       (from versions: ..., 0.8.10, 0.9.0)
```

Dependabot PR #118 bumped tabulate to `>=0.10.0`, but tabulate 0.10.0 **dropped Python 3.8 support**, and the onnx-tf images build `FROM ubuntu:20.04` (Python 3.8). Pinned the inline report dependency in both onnx-tf Dockerfiles to `tabulate>=0.8.10,<0.10`, mirroring the existing `pytest<9` pin. `setup/requirements_report.txt` is left unchanged so the Python 3.9+ runtimes keep tabulate 0.10.0.

Verified locally: `runtimes/onnx-tf/stable/Dockerfile` builds and resolves to tabulate 0.9.0 / pytest 8.3.5. Confirmed in CI — both onnx_tf jobs are now green.

## 2. Make deploy resilient to individual backend failures

`collect_and_deploy` declared `needs:` on all backend jobs without `always()`, so a single failing backend (e.g. a transient `ort-nightly` feed error) skipped the entire deploy and the scoreboard was not updated at all.

- Run `collect_and_deploy` with `always()`.
- Mark each artifact download `continue-on-error: true`.

The scoreboard now deploys with whatever results succeeded. `merge_trends.py` already preserves a backend's previous trend when its `report.json` is absent, so a failed backend keeps its last-good values instead of blocking the whole board. Individual backend jobs still surface as failed for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
