### PR TITLE
Add image decoding libraries to emx-onnx-cgen runtime for ImageDecoder

### DIFF
--- a/runtimes/emx-onnx-cgen/stable/Dockerfile
+++ b/runtimes/emx-onnx-cgen/stable/Dockerfile
@@ -8,12 +8,20 @@ ENV CC=gcc-14
 # Install Python, gcc and locales dependencies
 # emx-onnx-cgen needs a compiler with C23 _BitInt(N) support. Ubuntu 24.04's
 # default gcc-13 does not provide it on this target, so install and prefer gcc-14.
+# The image decoding libraries (libjpeg-turbo, libwebp, libtiff, openjpeg) back
+# the ImageDecoder operator; the onnx_backend links against them by default
+# since emx-onnx-cgen 1.4.0 and resolves openjpeg include dirs via pkg-config.
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-dev \
     python3-pip \
     gcc-14 \
     g++-14 \
+    pkg-config \
+    libjpeg-turbo8-dev \
+    libwebp-dev \
+    libtiff-dev \
+    libopenjp2-7-dev \
     locales && \
     apt-get clean autoclean && apt-get autoremove -y
 


### PR DESCRIPTION
## What

Adds the image decoding development libraries (and `pkg-config`) to the `emx-onnx-cgen/stable` runtime Dockerfile:

- `pkg-config`
- `libjpeg-turbo8-dev`
- `libwebp-dev`
- `libtiff-dev`
- `libopenjp2-7-dev`

## Why

Since **emx-onnx-cgen 1.4.0**, the `onnx_backend` links against libjpeg-turbo, libwebp, libtiff and openjpeg by default to back the **ImageDecoder** operator, and resolves the openjpeg include dirs via `pkg-config`. Without these `-dev` packages the image build fails. This change enables ImageDecoder support in the runtime image.

Only the `stable` variant exists under `runtimes/emx-onnx-cgen/`, so no other Dockerfile is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)