### PR TITLE
[OpenCV backend] Preserve input dtypes instead of forcing float32

### DIFF
--- a/backends/opencv/backend.py
+++ b/backends/opencv/backend.py
@@ -22,7 +22,10 @@ def _opencv_worker(model_bytes, inputs, input_names, output_names, result_queue)
     try:
         net = cv2.dnn.readNetFromONNX(path)
         for name, inp in zip(input_names, inputs, strict=True):
-            net.setInput(np.asarray(inp, dtype=np.float32), name)
+            # Feed each input with its declared ONNX dtype instead of forcing
+            # everything to float32, which corrupts non-float inputs such as
+            # int64 label/index tensors and boolean masks.
+            net.setInput(np.ascontiguousarray(inp), name)
         raw = net.forward(output_names)
         # forward() returns ndarray for single output, list for multiple
         if isinstance(raw, np.ndarray):


### PR DESCRIPTION
The OpenCV adapter cast every input to float32, corrupting non-float inputs (int64 labels/indices, bool masks) so those cases were skipped; this passes each input with its declared ONNX dtype instead. Coverage rises to **68.4%** after the fix.

_Note: measured against OpenCV's latest 5.x branch._

<img width="1705" height="596" alt="image" src="https://github.com/user-attachments/assets/2963bd95-6636-4abd-a393-dfacf60b4343" />
