### PR TITLE
Fix tract backend: use the new Python API

### DIFF
--- a/backends/tract/backend.py
+++ b/backends/tract/backend.py
@@ -20,7 +20,7 @@ def _tract_worker(model_bytes, inputs, output_count, result_queue):
         f.write(model_bytes)
         path = f.name
     try:
-        runnable = _tract.onnx().model_for_path(path).into_optimized().into_runnable()
+        runnable = _tract.onnx().load(path).into_model().into_runnable()
         tract_inputs = [np.asarray(inp) for inp in inputs]
         results = runnable.run(tract_inputs)
         output = [results[i].to_numpy() for i in range(output_count)]


### PR DESCRIPTION
The wrapper called `Onnx.model_for_path()` and `Model.into_optimized()`, which are names from the pre-0.23 API. The Python binding exposes `Onnx.load()` returning an InferenceModel, then `into_model()` to get a typed Model. So every model raised AttributeError in the worker process, which is not in the caught exception tuple, so the process died and every test was reported as a backend opt-out. 

With the fix, against onnx 1.22.0 and tract 0.23.6:
    20 failed, 1043 passed, 851 skipped

The remaining failures are genuine tract gaps.